### PR TITLE
Migrate all LLM calls from raw httpx to official OpenAI SDK

### DIFF
--- a/orchestrator/src/aspire_orchestrator/nodes/param_extract.py
+++ b/orchestrator/src/aspire_orchestrator/nodes/param_extract.py
@@ -101,8 +101,6 @@ async def param_extract_node(state: OrchestratorState) -> dict[str, Any]:
     fields for the routed tool. Fails closed if required fields cannot be extracted.
     Also builds advisor_context via context_builder for v1.5 prompt pack awareness.
     """
-    import httpx
-
     from aspire_orchestrator.config.settings import settings
 
     correlation_id = state.get("correlation_id", str(uuid.uuid4()))
@@ -227,31 +225,28 @@ async def param_extract_node(state: OrchestratorState) -> dict[str, Any]:
 
     if api_key:
         try:
+            import openai
+
             _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
             messages = [{"role": "developer" if _is_reasoning else "system", "content": "You are a precise parameter extractor. Return only valid JSON."}]
             messages.append({"role": "user", "content": prompt})
 
-            payload_llm: dict[str, Any] = {
+            client = openai.AsyncOpenAI(
+                api_key=api_key,
+                base_url=settings.openai_base_url,
+                timeout=25.0,
+            )
+
+            kwargs: dict[str, Any] = {
                 "model": model,
                 "messages": messages,
                 "max_completion_tokens": 1024,
             }
             if not _is_reasoning:
-                payload_llm["temperature"] = 0.0
+                kwargs["temperature"] = 0.0
 
-            with httpx.Client(timeout=25) as client:
-                resp = client.post(
-                    "https://api.openai.com/v1/chat/completions",
-                    json=payload_llm,
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                )
-                resp.raise_for_status()
-
-            data = resp.json()
-            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            response = await client.chat.completions.create(**kwargs)
+            content = response.choices[0].message.content or "" if response.choices else ""
 
             # Parse JSON from LLM response
             content = content.strip()

--- a/orchestrator/src/aspire_orchestrator/nodes/respond.py
+++ b/orchestrator/src/aspire_orchestrator/nodes/respond.py
@@ -307,49 +307,16 @@ def _llm_summarize(state: OrchestratorState, fallback_text: str) -> str:
     )
 
     try:
-        import asyncio
-        import os
-
-        import httpx
-
-        api_key = os.environ.get("ASPIRE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            return fallback_text
-
-        model = settings.router_model_classifier
-        _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
-
         messages = []
         if persona:
-            messages.append({"role": "developer" if _is_reasoning else "system", "content": persona})
+            messages.append({"role": "system", "content": persona})
         messages.append({"role": "user", "content": prompt})
 
-        payload: dict[str, Any] = {
-            "model": model,
-            "messages": messages,
-            "max_completion_tokens": 4096,
-        }
-        if not _is_reasoning:
-            payload["temperature"] = 0.3
+        content = _call_openai_sync(messages)
 
-        # Sync HTTP call (respond_node is sync in LangGraph)
-        with httpx.Client(timeout=8) as client:
-            resp = client.post(
-                "https://api.openai.com/v1/chat/completions",
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-            resp.raise_for_status()
-
-        data = resp.json()
-        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-
-        if content and content.strip():
+        if content:
             logger.info("LLM summarization success for %s (len=%d)", agent_id, len(content))
-            return content.strip()
+            return content
 
         return fallback_text
 
@@ -357,6 +324,57 @@ def _llm_summarize(state: OrchestratorState, fallback_text: str) -> str:
         # Law #3: Fail gracefully — use template response if LLM fails
         logger.warning("LLM summarization failed for %s: %s — using template", agent_id, e)
         return fallback_text
+
+
+def _call_openai_sync(
+    messages: list[dict[str, str]],
+    *,
+    model: str | None = None,
+    timeout: float = 8,
+) -> str:
+    """Shared sync OpenAI SDK call for respond node LLM operations.
+
+    Handles reasoning model logic (developer role, no temperature, 4096 min tokens).
+    Returns content string or empty string on failure.
+    """
+    import os
+
+    import openai
+
+    api_key = os.environ.get("ASPIRE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return ""
+
+    if model is None:
+        model = settings.router_model_classifier
+
+    _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
+
+    # Rewrite system role to developer for reasoning models
+    processed_messages = []
+    for msg in messages:
+        if msg["role"] == "system" and _is_reasoning:
+            processed_messages.append({"role": "developer", "content": msg["content"]})
+        else:
+            processed_messages.append(msg)
+
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "messages": processed_messages,
+        "max_completion_tokens": 4096,
+    }
+    if not _is_reasoning:
+        kwargs["temperature"] = 0.3
+
+    client = openai.OpenAI(
+        api_key=api_key,
+        base_url=settings.openai_base_url,
+        timeout=timeout,
+    )
+
+    response = client.chat.completions.create(**kwargs)
+    content = response.choices[0].message.content or "" if response.choices else ""
+    return content.strip()
 
 
 def _load_agent_persona(agent_id: str) -> str:
@@ -475,47 +493,16 @@ def _generate_approval_prompt(state: OrchestratorState) -> str:
     )
 
     try:
-        import os
-
-        import httpx
-
-        api_key = os.environ.get("ASPIRE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            return fallback_text
-
-        model = settings.router_model_classifier
-        _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
-
         messages = []
         if persona:
-            messages.append({"role": "developer" if _is_reasoning else "system", "content": persona})
+            messages.append({"role": "system", "content": persona})
         messages.append({"role": "user", "content": prompt})
 
-        payload: dict[str, Any] = {
-            "model": model,
-            "messages": messages,
-            "max_completion_tokens": 4096,
-        }
-        if not _is_reasoning:
-            payload["temperature"] = 0.3
+        content = _call_openai_sync(messages)
 
-        with httpx.Client(timeout=8) as client:
-            resp = client.post(
-                "https://api.openai.com/v1/chat/completions",
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-            resp.raise_for_status()
-
-        data = resp.json()
-        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-
-        if content and content.strip():
+        if content:
             logger.info("LLM approval prompt success for %s", agent_id)
-            return content.strip()
+            return content
 
         return fallback_text
 
@@ -577,47 +564,16 @@ def _generate_presence_prompt(state: OrchestratorState) -> str:
     )
 
     try:
-        import os
-
-        import httpx
-
-        api_key = os.environ.get("ASPIRE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            return fallback_text
-
-        model = settings.router_model_classifier
-        _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
-
         messages = []
         if persona:
-            messages.append({"role": "developer" if _is_reasoning else "system", "content": persona})
+            messages.append({"role": "system", "content": persona})
         messages.append({"role": "user", "content": prompt})
 
-        payload: dict[str, Any] = {
-            "model": model,
-            "messages": messages,
-            "max_completion_tokens": 4096,
-        }
-        if not _is_reasoning:
-            payload["temperature"] = 0.3
+        content = _call_openai_sync(messages)
 
-        with httpx.Client(timeout=8) as client:
-            resp = client.post(
-                "https://api.openai.com/v1/chat/completions",
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-            resp.raise_for_status()
-
-        data = resp.json()
-        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-
-        if content and content.strip():
+        if content:
             logger.info("LLM presence prompt success for %s", agent_id)
-            return content.strip()
+            return content
 
         return fallback_text
 

--- a/orchestrator/src/aspire_orchestrator/services/agent_sdk_base.py
+++ b/orchestrator/src/aspire_orchestrator/services/agent_sdk_base.py
@@ -270,11 +270,14 @@ class AspireAgentBase:
 
         Routes to the appropriate model based on step_type and risk_tier.
         Emits a model.route.selected receipt for every call.
+        Uses the official OpenAI SDK (AsyncOpenAI) for all API calls.
 
         Returns:
             dict with keys: content, model_used, profile_used, receipt
         """
-        import httpx
+        import os
+
+        import openai
 
         effective_risk = risk_tier or self._default_risk_tier
         effective_system = system_prompt or self._persona or ""
@@ -315,7 +318,6 @@ class AspireAgentBase:
                 logger.warning("LLM Router failed for agent %s: %s", self._agent_id, e)
 
         if not api_key:
-            import os
             api_key = os.environ.get("ASPIRE_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
 
         if not api_key:
@@ -328,8 +330,6 @@ class AspireAgentBase:
                 "receipt": route_receipt,
             }
 
-        # Make the LLM call
-        url = f"{base_url.rstrip('/')}/chat/completions"
         # Reasoning models (gpt-5*, o1, o3) don't support temperature or system role
         _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
 
@@ -344,28 +344,23 @@ class AspireAgentBase:
         if _is_reasoning and route_max_tokens < 4096:
             effective_max_tokens = 4096
 
-        payload: dict[str, Any] = {
-            "model": model,
-            "messages": messages,
-            "max_completion_tokens": effective_max_tokens,
-        }
-        if not _is_reasoning:
-            payload["temperature"] = route_temperature
-
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(
-                    url,
-                    json=payload,
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                )
-                resp.raise_for_status()
+            client = openai.AsyncOpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=float(timeout),
+            )
 
-            data = resp.json()
-            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            kwargs: dict[str, Any] = {
+                "model": model,
+                "messages": messages,
+                "max_completion_tokens": effective_max_tokens,
+            }
+            if not _is_reasoning:
+                kwargs["temperature"] = route_temperature
+
+            response = await client.chat.completions.create(**kwargs)
+            content = response.choices[0].message.content or "" if response.choices else ""
 
             return {
                 "content": content,
@@ -375,7 +370,7 @@ class AspireAgentBase:
                 "receipt": route_receipt,
             }
 
-        except httpx.TimeoutException:
+        except openai.APITimeoutError:
             logger.error("LLM call timeout for agent %s after %ds", self._agent_id, timeout)
             return {
                 "content": "",

--- a/orchestrator/src/aspire_orchestrator/services/intent_classifier.py
+++ b/orchestrator/src/aspire_orchestrator/services/intent_classifier.py
@@ -33,7 +33,7 @@ import logging
 import os
 from typing import Any
 
-import httpx
+import openai
 from pydantic import BaseModel, Field
 
 from aspire_orchestrator.models import RiskTier
@@ -300,14 +300,14 @@ class IntentClassifier:
             raw_response = await self._call_llm(user_message)
             return self._parse_response(raw_response)
 
-        except httpx.TimeoutException:
+        except openai.APITimeoutError:
             logger.error("Intent classifier LLM timeout after %ds", _LLM_TIMEOUT_SECONDS)
             return self._fail_closed_result(reason="intent_classifier_timeout")
 
-        except httpx.HTTPStatusError as e:
+        except openai.APIStatusError as e:
             logger.error(
                 "Intent classifier LLM HTTP error: status=%d",
-                e.response.status_code,
+                e.status_code,
             )
             return self._fail_closed_result(reason="intent_classifier_llm_http_error")
 
@@ -321,12 +321,11 @@ class IntentClassifier:
             return self._fail_closed_result(reason="intent_classifier_internal_error")
 
     async def _call_llm(self, user_message: str) -> dict[str, Any]:
-        """Call the OpenAI-compatible API with structured output (JSON mode).
+        """Call the OpenAI API with structured output (JSON mode).
 
         Phase 3: Uses LLM Router to select the appropriate model.
         Falls back to direct config when router unavailable.
-
-        Uses a fresh httpx.AsyncClient per call for thread safety.
+        Uses the official OpenAI SDK (AsyncOpenAI) for all API calls.
         """
         # Phase 3: Use LLM Router for model selection
         model = self._model
@@ -354,8 +353,6 @@ class IntentClassifier:
                 logger.warning("LLM Router failed, using fallback: %s", e)
                 self._last_route_decision = None
 
-        url = f"{base_url.rstrip('/')}/chat/completions"
-
         # Reasoning models (gpt-5*, o1, o3) don't support temperature or
         # system role — use developer role and omit temperature.
         _is_reasoning = model.startswith(("gpt-5", "o1", "o3"))
@@ -381,31 +378,26 @@ class IntentClassifier:
         if _is_reasoning and max_tokens < 4096:
             effective_max_tokens = 4096
 
-        payload: dict[str, Any] = {
+        client = openai.AsyncOpenAI(
+            api_key=self._api_key,
+            base_url=base_url,
+            timeout=float(timeout),
+        )
+
+        kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "response_format": {"type": "json_object"},
             "max_completion_tokens": effective_max_tokens,
         }
         if not _is_reasoning:
-            payload["temperature"] = temperature
+            kwargs["temperature"] = temperature
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(
-                url,
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-            resp.raise_for_status()
+        response = await client.chat.completions.create(**kwargs)
 
-        data = resp.json()
-        choice = data.get("choices", [{}])[0] if data.get("choices") else {}
-        message = choice.get("message", {})
-        content = message.get("content") or ""
-        finish_reason = choice.get("finish_reason", "unknown")
+        choice = response.choices[0] if response.choices else None
+        content = choice.message.content or "" if choice else ""
+        finish_reason = choice.finish_reason or "unknown" if choice else "unknown"
 
         if not content:
             logger.error(


### PR DESCRIPTION
Replace raw httpx HTTP calls with the official openai Python SDK (AsyncOpenAI/OpenAI) across all 4 LLM call sites:

- agent_sdk_base.py: AsyncOpenAI for call_llm() — powers all 14 skill packs
- intent_classifier.py: AsyncOpenAI for _call_llm() — intent classification
- respond.py: sync OpenAI via shared _call_openai_sync() helper — consolidates 3 duplicate httpx blocks (_llm_summarize, _generate_approval_prompt, _generate_presence_prompt) into one reusable function
- param_extract.py: AsyncOpenAI for parameter extraction (was async def using sync httpx.Client)

Preserves all existing behavior: LLM Router integration, reasoning model handling (developer role, no temperature, 4096 min tokens), receipt emission, fail-closed error handling, and JSON mode for classification.

https://claude.ai/code/session_01TdMYKAATGZfLrGY3uuLv5e