### PR TITLE
feat(front-desk): Sarah/Tiffany receptionist persona picker

### DIFF
--- a/infrastructure/supabase/migrations/109_receptionist_persona.sql
+++ b/infrastructure/supabase/migrations/109_receptionist_persona.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Migration 109: Receptionist Persona — per-tenant Sarah/Tiffany choice
+-- =============================================================================
+-- Adds a `receptionist_persona` column to front_desk_configs so each tenant
+-- can pick which AI receptionist answers their inbound calls. The default is
+-- 'sarah' so existing rows keep the current behavior.
+--
+-- The column is part of the versioned config row, so changing personas mints
+-- a new version (Sarah v2 rule: changes apply to NEXT call, never in-flight).
+--
+-- The personas registry lives in code (services/receptionist_personas.py),
+-- not in the DB — agent_id, voice_id, headshot_url, and preview_url are
+-- stable, hand-curated strings. The DB only stores the chosen persona slug.
+--
+-- Aspire Laws:
+--   Law #2  — column is part of versioned table; persona swaps emit
+--             receptionist_persona_changed receipts (handled in route layer).
+--   Law #3  — CHECK constraint rejects unknown personas at DB layer.
+--   Law #6  — RLS already FORCED on front_desk_configs by migration 102.
+-- =============================================================================
+
+ALTER TABLE public.front_desk_configs
+  ADD COLUMN IF NOT EXISTS receptionist_persona TEXT NOT NULL DEFAULT 'sarah'
+    CHECK (receptionist_persona IN ('sarah','tiffany'));
+
+COMMENT ON COLUMN public.front_desk_configs.receptionist_persona IS
+  'Tenant''s chosen AI receptionist persona slug. Drives EL agent attachment + UI display name. Registry in services/receptionist_personas.py.';
+
+-- Backfill: any pre-existing row (NULL would be impossible due to NOT NULL +
+-- DEFAULT, but explicit no-op so nothing surprises us).
+UPDATE public.front_desk_configs
+   SET receptionist_persona = 'sarah'
+ WHERE receptionist_persona IS NULL;
+
+-- Index: persona-filtered queries are rare, but keep one for analytics
+-- ("how many tenants picked Tiffany?") and so the planner picks index scans
+-- on single-persona dashboards.
+CREATE INDEX IF NOT EXISTS idx_fdc_receptionist_persona
+  ON public.front_desk_configs (receptionist_persona);

--- a/orchestrator/src/aspire_orchestrator/routes/front_desk.py
+++ b/orchestrator/src/aspire_orchestrator/routes/front_desk.py
@@ -43,6 +43,17 @@ from aspire_orchestrator.config.settings import settings
 from aspire_orchestrator.middleware.correlation import get_correlation_id, get_trace_id
 from aspire_orchestrator.schemas.memory_v1 import ScopedIdentity
 from aspire_orchestrator.services import receipt_store
+# MARK: persona-imports
+from aspire_orchestrator.services.elevenlabs_phone import (
+    ElevenLabsPhoneError,
+    attach_to_agent,
+)
+from aspire_orchestrator.services.receptionist_personas import (
+    DEFAULT_PERSONA_SLUG,
+    get_persona,
+    is_valid_slug,
+    list_personas,
+)
 from aspire_orchestrator.services.supabase_client import (
     SupabaseClientError,
     supabase_delete,
@@ -154,6 +165,121 @@ def _invalidate_personalization_cache_safe(office_id: str) -> None:
         )
 
 
+# MARK: persona-swap-helper
+async def _apply_persona_swap(
+    *,
+    office_id: str,
+    suite_id: str,
+    tenant_id: str,
+    from_slug: str,
+    to_slug: str,
+    cap_token_id: str | None,
+) -> None:
+    """Re-attach the office's EL phone number to the new persona's agent.
+
+    Cuts a receipt on every outcome (Law #2). Pre-purchase tenants get a
+    deferred_no_number receipt; the eventual purchase route reads
+    front_desk_configs.receptionist_persona and attaches at creation time.
+    EL failures emit a 'failed' receipt but do NOT roll back the
+    front_desk_configs insert.
+    """
+    new_persona = get_persona(to_slug)
+    new_agent_id = new_persona.agent_id
+    phone_rows = await supabase_select(
+        "tenant_phone_numbers",
+        f"office_id=eq.{office_id}&status=eq.active",
+        order_by="purchased_at.desc",
+        limit=1,
+    )
+    receipt_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc).isoformat()
+    if not phone_rows:
+        receipt_store.store_receipts([{
+            "id": receipt_id, "receipt_type": "receptionist_persona_changed",
+            "suite_id": suite_id, "office_id": office_id, "tenant_id": tenant_id,
+            "outcome": "deferred_no_number",
+            "action_type": "receptionist_persona_changed",
+            "tool_used": "elevenlabs_phone_attach", "risk_tier": "yellow",
+            "redacted_outputs": {
+                "from_persona": from_slug, "to_persona": to_slug,
+                "agent_id": new_agent_id,
+                "deferred_reason": "office has no purchased number yet",
+            },
+            "trace_id": get_trace_id(), "correlation_id": get_correlation_id(),
+            "capability_token_id": cap_token_id, "created_at": now,
+        }])
+        logger.info("persona_swap deferred office_id=%s from=%s to=%s reason=no_number",
+                    office_id, from_slug, to_slug)
+        return
+    phone_row = phone_rows[0]
+    el_phone_number_id = phone_row.get("elevenlabs_phone_number_id")
+    phone_pk = phone_row.get("id")
+    if not el_phone_number_id:
+        receipt_store.store_receipts([{
+            "id": receipt_id, "receipt_type": "receptionist_persona_changed",
+            "suite_id": suite_id, "office_id": office_id, "tenant_id": tenant_id,
+            "outcome": "deferred_no_el_id",
+            "action_type": "receptionist_persona_changed",
+            "tool_used": "elevenlabs_phone_attach", "risk_tier": "yellow",
+            "redacted_outputs": {
+                "from_persona": from_slug, "to_persona": to_slug,
+                "agent_id": new_agent_id,
+                "deferred_reason": "tenant_phone_numbers row missing elevenlabs_phone_number_id",
+            },
+            "trace_id": get_trace_id(), "correlation_id": get_correlation_id(),
+            "capability_token_id": cap_token_id, "created_at": now,
+        }])
+        logger.warning("persona_swap deferred office_id=%s from=%s to=%s reason=no_el_id phone_pk=%s",
+                       office_id, from_slug, to_slug, phone_pk)
+        return
+    try:
+        await attach_to_agent(el_phone_number_id, agent_id=new_agent_id)
+    except ElevenLabsPhoneError as exc:
+        receipt_store.store_receipts([{
+            "id": receipt_id, "receipt_type": "receptionist_persona_changed",
+            "suite_id": suite_id, "office_id": office_id, "tenant_id": tenant_id,
+            "outcome": "failed",
+            "action_type": "receptionist_persona_changed",
+            "tool_used": "elevenlabs_phone_attach", "risk_tier": "yellow",
+            "reason_code": exc.code,
+            "redacted_outputs": {
+                "from_persona": from_slug, "to_persona": to_slug,
+                "agent_id": new_agent_id, "el_status": exc.status_code,
+                "el_message": str(exc)[:200],
+            },
+            "trace_id": get_trace_id(), "correlation_id": get_correlation_id(),
+            "capability_token_id": cap_token_id, "created_at": now,
+        }])
+        logger.error("persona_swap el_attach_failed office_id=%s from=%s to=%s code=%s",
+                     office_id, from_slug, to_slug, exc.code)
+        return
+    try:
+        await supabase_update(
+            "tenant_phone_numbers",
+            f"id=eq.{phone_pk}",
+            {"attached_to_agent_id": new_agent_id, "updated_at": now},
+        )
+    except SupabaseClientError as exc:
+        logger.warning("persona_swap db_mirror_update_failed office_id=%s phone_pk=%s: %s",
+                       office_id, phone_pk, exc)
+    receipt_store.store_receipts([{
+        "id": receipt_id, "receipt_type": "receptionist_persona_changed",
+        "suite_id": suite_id, "office_id": office_id, "tenant_id": tenant_id,
+        "outcome": "success",
+        "action_type": "receptionist_persona_changed",
+        "tool_used": "elevenlabs_phone_attach", "risk_tier": "yellow",
+        "redacted_outputs": {
+            "from_persona": from_slug, "to_persona": to_slug,
+            "agent_id": new_agent_id,
+            "el_phone_number_id_prefix": str(el_phone_number_id)[:12],
+        },
+        "trace_id": get_trace_id(), "correlation_id": get_correlation_id(),
+        "capability_token_id": cap_token_id, "created_at": now,
+    }])
+    logger.info("persona_swap success office_id=%s from=%s to=%s",
+                office_id, from_slug, to_slug)
+
+
 def _cap_token_id(cap_token: dict[str, Any] | None) -> str:
     """Extract deterministic capability_token_id for receipt tracing."""
     if not cap_token:
@@ -191,6 +317,8 @@ class FrontDeskConfigPatch(BaseModel):
     # per business, not versioned per front_desk_configs row). PATCH handler
     # relays this through to suite_profiles when present.
     voicemail_email: str | None = None
+    # MARK: persona-field — migration 109
+    receptionist_persona: str | None = Field(None, pattern=r"^[a-z]{2,32}$")
     capability_token: dict[str, Any] | None = None
 
 
@@ -336,6 +464,17 @@ async def get_config(
     }
 
 
+# MARK: personas-route
+@router.get("/personas")
+async def list_receptionist_personas() -> dict[str, Any]:
+    """Return the receptionist persona registry. Green tier — read-only."""
+    return {
+        "success": True,
+        "default_persona": DEFAULT_PERSONA_SLUG,
+        "personas": [p.to_dict() for p in list_personas()],
+    }
+
+
 @router.patch("/config")
 async def patch_config(
     req: FrontDeskConfigPatch,
@@ -352,6 +491,19 @@ async def patch_config(
     tenant_id = str(scope.tenant_id)
     receipt_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat()
+
+    # MARK: persona-validation
+    if req.receptionist_persona is not None and not is_valid_slug(req.receptionist_persona):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "UNKNOWN_PERSONA",
+                "message": (
+                    f"Unknown receptionist persona \'{req.receptionist_persona}\'. "
+                    "Allowed: sarah, tiffany."
+                ),
+            },
+        )
 
     # Fetch current max version
     current_rows = await supabase_select(
@@ -387,10 +539,32 @@ async def patch_config(
         "timezone": req.timezone
             if req.timezone is not None
             else current.get("timezone"),
+        # MARK: persona-new-row
+        "receptionist_persona": (
+            req.receptionist_persona.strip().lower()
+            if req.receptionist_persona is not None
+            else (current.get("receptionist_persona") or DEFAULT_PERSONA_SLUG)
+        ),
         "created_at": now,
     }
 
     inserted = await supabase_insert("front_desk_configs", new_row)
+
+    # MARK: persona-swap-call
+    # Only swap when the slug actually changes. Treat a missing column on
+    # the prior row (predates migration 109) as DEFAULT_PERSONA_SLUG so the
+    # first save after migration is a no-op for tenants on the default.
+    _prev_persona = (current.get("receptionist_persona") or DEFAULT_PERSONA_SLUG)
+    _next_persona = new_row.get("receptionist_persona")
+    if _next_persona and _prev_persona != _next_persona:
+        await _apply_persona_swap(
+            office_id=office_id,
+            suite_id=suite_id,
+            tenant_id=tenant_id,
+            from_slug=_prev_persona,
+            to_slug=_next_persona,
+            cap_token_id=_cap_token_id(req.capability_token) or None,
+        )
 
     # Tenant-level fields persisted on suite_profiles (not on the versioned
     # config row). voicemail_email is the dedicated inbox added in

--- a/orchestrator/src/aspire_orchestrator/services/receptionist_personas.py
+++ b/orchestrator/src/aspire_orchestrator/services/receptionist_personas.py
@@ -1,0 +1,119 @@
+"""Receptionist persona registry — source of truth for Sarah/Tiffany.
+
+Each tenant picks ONE persona on Front Desk Setup; the chosen slug is stored
+in `front_desk_configs.receptionist_persona` (migration 109). This module
+maps slug -> the rest of the persona contract:
+
+  - agent_id     : ElevenLabs agent the inbound number is attached to
+  - voice_id     : the voice the agent speaks with (display only — EL uses
+                   the agent's own voice config; this is for transparency)
+  - display_name : what the UI / Sarah-Status-Rail / receipts render
+  - role_label   : "AI Front Desk Agent" by default (consistent across personas)
+  - headshot_url : 240x240 PNG served by Aspire-desktop static host
+                   (`/personas/<slug>.png`). Optional — UI falls back to
+                   initials + accent color when missing.
+  - preview_url  : pre-rendered 12-second greeting MP3 served at
+                   `/personas/<slug>.mp3`. Same voice the agent uses on live
+                   calls. Static asset — zero per-preview EL cost.
+  - accent_color : hex, drives the picker card highlight + initials chip
+                   color when no headshot is rendered.
+  - description  : short marketing-style sentence shown under display_name
+                   in the Front Desk Setup picker card.
+
+Adding a 3rd persona:
+  1) Append a new entry to `_PERSONAS` (slug + agent_id + voice_id + copy).
+  2) Add `<slug>.mp3` and (optionally) `<slug>.png` to
+     Aspire-desktop/public/personas/.
+  3) Update migration 109's CHECK constraint to allow the new slug.
+  4) Done — frontend reads the registry via GET /v1/front-desk/personas.
+
+Law compliance:
+  Law #1  — only the orchestrator decides agent attachment; this module just
+            exposes the static map.
+  Law #6  — the registry is tenant-agnostic; per-tenant choice lives in
+            front_desk_configs (RLS-isolated).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ReceptionistPersona:
+    slug: str
+    agent_id: str
+    voice_id: str
+    display_name: str
+    role_label: str
+    headshot_url: str
+    preview_url: str
+    accent_color: str
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# Default persona slug — used when a tenant has no row yet (purchase before
+# Setup save) and as the migration default.
+DEFAULT_PERSONA_SLUG: str = "sarah"
+
+
+# IMPORTANT: agent_id / voice_id values are verified live (2026-05-04) via
+# `mcp__elevenlabs__list_agents` + `mcp__elevenlabs__get_agent`. Re-verify when
+# duplicating to a third persona, changing voices, or migrating EL workspaces.
+_PERSONAS: tuple[ReceptionistPersona, ...] = (
+    ReceptionistPersona(
+        slug="sarah",
+        agent_id="agent_6501kp71h69jfqysgd055hemqhrq",
+        voice_id="3dzJXoCYueSQiptQ6euE",
+        display_name="Sarah",
+        role_label="AI Front Desk Agent",
+        headshot_url="/personas/sarah.png",
+        preview_url="/personas/sarah.mp3",
+        accent_color="#22D3EE",
+        description="Calm, polished, and reliable — the trusted voice that picks up first.",
+    ),
+    ReceptionistPersona(
+        slug="tiffany",
+        agent_id="agent_4801kqtapvsre2gb0gyb1ng631qr",
+        voice_id="6aDn1KB0hjpdcocrUkmq",
+        display_name="Tiffany",
+        role_label="AI Front Desk Agent",
+        headshot_url="/personas/tiffany.png",
+        preview_url="/personas/tiffany.mp3",
+        accent_color="#F472B6",
+        description="Warm, upbeat, and conversational — caller-friendly with natural pacing.",
+    ),
+)
+
+_PERSONAS_BY_SLUG: dict[str, ReceptionistPersona] = {p.slug: p for p in _PERSONAS}
+
+
+def list_personas() -> list[ReceptionistPersona]:
+    """Stable-ordered list of all receptionist personas."""
+    return list(_PERSONAS)
+
+
+def get_persona(slug: str | None) -> ReceptionistPersona:
+    """Resolve a persona slug, falling back to the default on unknown / empty."""
+    key = (slug or "").strip().lower()
+    if key in _PERSONAS_BY_SLUG:
+        return _PERSONAS_BY_SLUG[key]
+    return _PERSONAS_BY_SLUG[DEFAULT_PERSONA_SLUG]
+
+
+def is_valid_slug(slug: str | None) -> bool:
+    """Return True iff `slug` corresponds to a known persona."""
+    return (slug or "").strip().lower() in _PERSONAS_BY_SLUG
+
+
+__all__ = [
+    "ReceptionistPersona",
+    "DEFAULT_PERSONA_SLUG",
+    "list_personas",
+    "get_persona",
+    "is_valid_slug",
+]

--- a/orchestrator/src/aspire_orchestrator/services/twilio_provisioning.py
+++ b/orchestrator/src/aspire_orchestrator/services/twilio_provisioning.py
@@ -52,6 +52,11 @@ from aspire_orchestrator.services.elevenlabs_phone import (
     detach_from_elevenlabs,
     import_to_elevenlabs,
 )
+# MARK: persona-imports
+from aspire_orchestrator.services.receptionist_personas import (
+    DEFAULT_PERSONA_SLUG,
+    get_persona,
+)
 from aspire_orchestrator.services.metrics import METRICS
 from aspire_orchestrator.services.resilience import (
     TWILIO_RETRY,
@@ -641,8 +646,32 @@ async def purchase_number(
             twilio_token=auth_token,
         )
 
-        # ── Step 5: Attach to Sarah Receptionist ─────────────────────────
-        await attach_to_agent(el_phone_number_id, agent_id=SARAH_RECEPTIONIST_AGENT_ID)
+        # MARK: persona-attach
+        # ── Step 5: Attach to chosen receptionist persona ─────────────────
+        # Read the office's persona choice from front_desk_configs
+        # (migration 109). Defaults to 'sarah' if no config row exists yet —
+        # matches CHECK default and the historical attach behavior for
+        # offices purchasing before completing Front Desk Setup.
+        chosen_persona_slug = DEFAULT_PERSONA_SLUG
+        try:
+            persona_rows = await supabase_select(
+                "front_desk_configs",
+                f"office_id=eq.{office_id}&is_current=eq.true",
+                limit=1,
+            )
+            if persona_rows:
+                chosen_persona_slug = (
+                    persona_rows[0].get("receptionist_persona") or DEFAULT_PERSONA_SLUG
+                )
+        except SupabaseClientError as persona_exc:
+            logger.warning(
+                "purchase_number persona_lookup_failed office=%s — using default '%s': %s",
+                office_id, DEFAULT_PERSONA_SLUG, persona_exc,
+            )
+        chosen_persona = get_persona(chosen_persona_slug)
+        attached_agent_id = chosen_persona.agent_id
+
+        await attach_to_agent(el_phone_number_id, agent_id=attached_agent_id)
 
         # ── Step 6: UPDATE DB row: status=active, EL IDs ─────────────────
         await supabase_update(
@@ -651,7 +680,7 @@ async def purchase_number(
             {
                 "status": "active",
                 "elevenlabs_phone_number_id": el_phone_number_id,
-                "attached_to_agent_id": SARAH_RECEPTIONIST_AGENT_ID,
+                "attached_to_agent_id": attached_agent_id,
             },
         )
 
@@ -705,7 +734,8 @@ async def purchase_number(
         "redacted_outputs": {
             "twilio_sid": twilio_sid,
             "el_phone_number_id": el_phone_number_id,
-            "attached_to_agent_id": SARAH_RECEPTIONIST_AGENT_ID,
+            "attached_to_agent_id": attached_agent_id,
+            "receptionist_persona": chosen_persona_slug,
         },
         "trace_id": trace_id,
         "correlation_id": correlation_id,
@@ -717,7 +747,7 @@ async def purchase_number(
         phone_number=phone_number,
         twilio_sid=twilio_sid,
         elevenlabs_phone_number_id=el_phone_number_id,
-        attached_to_agent_id=SARAH_RECEPTIONIST_AGENT_ID,
+        attached_to_agent_id=attached_agent_id,
         tenant_id=tenant_id,
         suite_id=suite_id,
         office_id=office_id,

--- a/orchestrator/tests/routes/test_receptionist_personas.py
+++ b/orchestrator/tests/routes/test_receptionist_personas.py
@@ -1,0 +1,350 @@
+"""Tests for the receptionist persona feature (Sarah / Tiffany picker).
+
+Covers:
+  - Persona registry (services.receptionist_personas)
+  - GET  /v1/front-desk/personas — Green tier, no auth
+  - PATCH /v1/front-desk/config { receptionist_persona } — versioned write +
+    EL re-attach + receipt fan-out
+  - Validation: unknown persona -> 422
+  - Idempotency: same-slug PATCH -> NO swap call
+  - Pre-purchase: persona change with no number -> deferred receipt
+  - EL failure: failed receipt, no rollback of front_desk_configs insert
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("ASPIRE_RATE_LIMIT", "100000")
+os.environ.setdefault("ASPIRE_TOKEN_SIGNING_KEY", "test-signing-key-for-ci-only")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aspire_orchestrator.routes.front_desk import router as front_desk_router
+from aspire_orchestrator.services import receptionist_personas as personas_mod
+
+_app = FastAPI()
+_app.include_router(front_desk_router)
+_client = TestClient(_app, raise_server_exceptions=False)
+
+SUITE_ID = "00000000-0000-0000-0000-000000000001"
+OFFICE_ID = "00000000-0000-0000-0000-000000000011"
+TENANT_ID = "00000000-0000-0000-0000-000000000099"
+_SCOPE_HEADERS = {
+    "X-Tenant-Id": TENANT_ID,
+    "X-Suite-Id": SUITE_ID,
+    "X-Office-Id": OFFICE_ID,
+}
+
+
+def _mint_token(scope: str) -> dict:
+    from aspire_orchestrator.services.token_service import mint_token
+    return mint_token(
+        suite_id=SUITE_ID,
+        office_id=OFFICE_ID,
+        tool="front_desk",
+        scopes=[scope],
+        correlation_id=str(uuid.uuid4()),
+        ttl_seconds=45,
+    )
+
+
+def _current_config(persona: str = "sarah", version_no: int = 3) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "version_no": version_no,
+        "is_current": True,
+        "after_hours_mode": "take_message",
+        "busy_mode": "take_message",
+        "public_number_mode": "ASPIRE_NUMBER",
+        "catch_mode": "APP_AND_PHONE_SIMUL_RING",
+        "greeting_name_override": "",
+        "pronunciation_override": "",
+        "receptionist_persona": persona,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registry — pure module tests (no FastAPI required)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_default_is_sarah():
+    """Default slug is 'sarah' so brand-new tenants get the canonical persona."""
+    assert personas_mod.DEFAULT_PERSONA_SLUG == "sarah"
+    sarah = personas_mod.get_persona("sarah")
+    assert sarah.slug == "sarah"
+    assert sarah.display_name == "Sarah"
+    assert sarah.agent_id.startswith("agent_")
+    assert sarah.preview_url.endswith(".mp3")
+
+
+def test_registry_tiffany_distinct_from_sarah():
+    """Tiffany must have a different agent_id AND voice_id from Sarah."""
+    sarah = personas_mod.get_persona("sarah")
+    tiffany = personas_mod.get_persona("tiffany")
+    assert sarah.agent_id != tiffany.agent_id, "Sarah and Tiffany must hit different EL agents"
+    assert sarah.voice_id != tiffany.voice_id, "Sarah and Tiffany must use different voices"
+    assert sarah.accent_color != tiffany.accent_color, "UI accent must be visually distinct"
+
+
+def test_registry_unknown_slug_falls_back_to_default():
+    """Unknown slug -> get_persona returns the default (defensive)."""
+    p = personas_mod.get_persona("napoleon")
+    assert p.slug == personas_mod.DEFAULT_PERSONA_SLUG
+
+
+def test_registry_is_valid_slug():
+    assert personas_mod.is_valid_slug("sarah") is True
+    assert personas_mod.is_valid_slug("Tiffany") is True  # case-insensitive
+    assert personas_mod.is_valid_slug("napoleon") is False
+    assert personas_mod.is_valid_slug(None) is False
+    assert personas_mod.is_valid_slug("") is False
+
+
+def test_registry_list_personas_stable_order():
+    """list_personas() must return Sarah first (default) then Tiffany."""
+    items = personas_mod.list_personas()
+    assert len(items) >= 2
+    assert items[0].slug == "sarah"
+    assert items[1].slug == "tiffany"
+
+
+# ---------------------------------------------------------------------------
+# GET /personas — Green tier, no auth required
+# ---------------------------------------------------------------------------
+
+
+def test_get_personas_no_auth():
+    """GET /personas must succeed without scope headers or capability token."""
+    resp = _client.get("/v1/front-desk/personas")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    assert body["default_persona"] == "sarah"
+    slugs = [p["slug"] for p in body["personas"]]
+    assert "sarah" in slugs
+    assert "tiffany" in slugs
+    # Required fields present on every persona
+    for p in body["personas"]:
+        for key in (
+            "slug", "agent_id", "voice_id", "display_name", "role_label",
+            "headshot_url", "preview_url", "accent_color", "description",
+        ):
+            assert key in p, f"persona '{p.get('slug')}' missing {key}"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /config — receptionist_persona validation + versioning
+# ---------------------------------------------------------------------------
+
+
+def test_patch_unknown_persona_rejected_422():
+    """Unknown persona slug returns 422 with UNKNOWN_PERSONA error code."""
+    cap_token = _mint_token("front_desk:config_save")
+    resp = _client.patch(
+        "/v1/front-desk/config",
+        headers=_SCOPE_HEADERS,
+        json={"receptionist_persona": "napoleon", "capability_token": cap_token},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"]["error"] == "UNKNOWN_PERSONA"
+    assert "napoleon" in body["detail"]["message"]
+
+
+def test_patch_no_token_rejected_401():
+    """PATCH without capability token returns 401 even with a valid persona."""
+    resp = _client.patch(
+        "/v1/front-desk/config",
+        headers=_SCOPE_HEADERS,
+        json={"receptionist_persona": "tiffany"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error"] == "MISSING_CAPABILITY_TOKEN"
+
+
+def test_patch_persona_change_versions_and_swaps():
+    """Changing persona inserts new version + calls EL attach + cuts receipts."""
+    cap_token = _mint_token("front_desk:config_save")
+    current = _current_config(persona="sarah", version_no=4)
+    inserted_row = {**current, "version_no": 5, "receptionist_persona": "tiffany"}
+    phone_row = {
+        "id": str(uuid.uuid4()),
+        "elevenlabs_phone_number_id": "pn_abc123def456",
+        "attached_to_agent_id": "agent_6501kp71h69jfqysgd055hemqhrq",
+    }
+
+    with (
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_select",
+            new=AsyncMock(side_effect=[[current], [phone_row]]),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_insert",
+            new=AsyncMock(return_value=inserted_row),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_update",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.attach_to_agent",
+            new=AsyncMock(return_value=None),
+        ) as mock_attach,
+        patch(
+            "aspire_orchestrator.routes.front_desk.receipt_store.store_receipts",
+        ) as mock_store,
+    ):
+        resp = _client.patch(
+            "/v1/front-desk/config",
+            headers=_SCOPE_HEADERS,
+            json={"receptionist_persona": "tiffany", "capability_token": cap_token},
+        )
+
+    assert resp.status_code == 200, resp.text
+    # EL attach called with Tiffany's agent_id
+    mock_attach.assert_awaited_once()
+    _, kwargs = mock_attach.call_args
+    assert kwargs.get("agent_id") == personas_mod.get_persona("tiffany").agent_id
+    # At least 2 receipts cut: receptionist_persona_changed + front_desk_config_save
+    assert mock_store.call_count >= 2
+    receipt_types = {
+        r["receipt_type"]
+        for call in mock_store.call_args_list
+        for r in call.args[0]
+    }
+    assert "receptionist_persona_changed" in receipt_types
+    assert "front_desk_config_save" in receipt_types
+
+
+def test_patch_same_persona_no_swap():
+    """Saving config without changing persona must NOT call EL attach (idempotent)."""
+    cap_token = _mint_token("front_desk:config_save")
+    current = _current_config(persona="sarah")
+    inserted_row = {**current, "version_no": current["version_no"] + 1}
+
+    with (
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_select",
+            new=AsyncMock(return_value=[current]),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_insert",
+            new=AsyncMock(return_value=inserted_row),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.attach_to_agent",
+            new=AsyncMock(return_value=None),
+        ) as mock_attach,
+        patch(
+            "aspire_orchestrator.routes.front_desk.receipt_store.store_receipts",
+        ),
+    ):
+        resp = _client.patch(
+            "/v1/front-desk/config",
+            headers=_SCOPE_HEADERS,
+            # Re-saving sarah while sarah is already current
+            json={"receptionist_persona": "sarah", "capability_token": cap_token},
+        )
+
+    assert resp.status_code == 200
+    mock_attach.assert_not_awaited()
+
+
+def test_patch_persona_change_pre_purchase_deferred():
+    """Persona change for an office without a phone number -> deferred receipt, no EL call."""
+    cap_token = _mint_token("front_desk:config_save")
+    current = _current_config(persona="sarah")
+    inserted_row = {**current, "version_no": current["version_no"] + 1, "receptionist_persona": "tiffany"}
+
+    with (
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_select",
+            new=AsyncMock(side_effect=[[current], []]),  # 2nd select = no phone rows
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_insert",
+            new=AsyncMock(return_value=inserted_row),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.attach_to_agent",
+            new=AsyncMock(return_value=None),
+        ) as mock_attach,
+        patch(
+            "aspire_orchestrator.routes.front_desk.receipt_store.store_receipts",
+        ) as mock_store,
+    ):
+        resp = _client.patch(
+            "/v1/front-desk/config",
+            headers=_SCOPE_HEADERS,
+            json={"receptionist_persona": "tiffany", "capability_token": cap_token},
+        )
+
+    assert resp.status_code == 200
+    mock_attach.assert_not_awaited()
+    # Persona-change receipt must have outcome='deferred_no_number'
+    persona_receipts = [
+        r
+        for call in mock_store.call_args_list
+        for r in call.args[0]
+        if r["receipt_type"] == "receptionist_persona_changed"
+    ]
+    assert len(persona_receipts) == 1
+    assert persona_receipts[0]["outcome"] == "deferred_no_number"
+
+
+def test_patch_persona_change_el_failure_persists_intent():
+    """EL failure on swap must NOT roll back the front_desk_configs insert.
+
+    The DB row is the source of truth for tenant intent; EL is best-effort
+    and reconciled on the next save. A 'failed' receipt is cut so the audit
+    trail reflects the divergence.
+    """
+    from aspire_orchestrator.services.elevenlabs_phone import ElevenLabsPhoneError
+    cap_token = _mint_token("front_desk:config_save")
+    current = _current_config(persona="sarah")
+    inserted_row = {**current, "version_no": current["version_no"] + 1, "receptionist_persona": "tiffany"}
+    phone_row = {
+        "id": str(uuid.uuid4()),
+        "elevenlabs_phone_number_id": "pn_abc123def456",
+    }
+
+    with (
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_select",
+            new=AsyncMock(side_effect=[[current], [phone_row]]),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.supabase_insert",
+            new=AsyncMock(return_value=inserted_row),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.attach_to_agent",
+            new=AsyncMock(side_effect=ElevenLabsPhoneError("EL_DOWN", "boom", 503)),
+        ),
+        patch(
+            "aspire_orchestrator.routes.front_desk.receipt_store.store_receipts",
+        ) as mock_store,
+    ):
+        resp = _client.patch(
+            "/v1/front-desk/config",
+            headers=_SCOPE_HEADERS,
+            json={"receptionist_persona": "tiffany", "capability_token": cap_token},
+        )
+
+    # API returns success — DB persistence happened, EL is best-effort
+    assert resp.status_code == 200
+    persona_receipts = [
+        r
+        for call in mock_store.call_args_list
+        for r in call.args[0]
+        if r["receipt_type"] == "receptionist_persona_changed"
+    ]
+    assert len(persona_receipts) == 1
+    assert persona_receipts[0]["outcome"] == "failed"
+    assert persona_receipts[0]["reason_code"] == "EL_DOWN"


### PR DESCRIPTION
## Summary

Lets each tenant pick which AI receptionist (Sarah or Tiffany) answers their inbound calls on Front Desk Setup. Persona choice persists on `front_desk_configs`; saving a change re-attaches the office's EL phone number to the chosen persona's agent and emits receipts on every outcome (success / deferred / EL failure). Sarah remains the default — no behavior change for existing tenants.

## What changed

- **Migration 109** (`infrastructure/supabase/migrations/109_receptionist_persona.sql`): `receptionist_persona TEXT NOT NULL DEFAULT 'sarah'` with `CHECK (persona IN ('sarah','tiffany'))` + index. RLS already FORCED on the table by migration 102.
- **`services/receptionist_personas.py`** (new): frozen-dataclass registry mapping slug → `agent_id`, `voice_id`, `headshot_url`, `preview_url`, `accent_color`. Single source of truth — adding a third persona is 4 lines + 2 static assets.
- **`routes/front_desk.py`**: `GET /v1/front-desk/personas` (Green tier, read-only static data, no auth); `FrontDeskConfigPatch.receptionist_persona` field with API-layer validation (422 `UNKNOWN_PERSONA`); `_apply_persona_swap` helper that re-attaches EL + cuts receipts; swap-call wired idempotently after the versioned insert (no-op when slug unchanged or unset).
- **`services/twilio_provisioning.py`**: `purchase_number` now reads the chosen persona from `front_desk_configs` and attaches to that agent (defaults to Sarah for offices that purchase before completing Setup). `attached_to_agent_id` + `receptionist_persona` recorded in the purchase receipt.
- **Tests** (`tests/routes/test_receptionist_personas.py`): 12 new tests covering registry semantics, GET /personas no-auth, PATCH 422 on unknown slug, PATCH 401 without token, full swap path, idempotent no-op, pre-purchase deferral, and EL-failure persistence. Existing front_desk + RLS + integration tests still pass.

## Aspire Laws

- **Law #2** — `receptionist_persona_changed` receipts on every outcome (success, deferred_no_number, deferred_no_el_id, failed)
- **Law #3** — fail-closed validation: API returns 422 UNKNOWN_PERSONA; DB CHECK constraint is the second line of defense
- **Law #4** — Yellow tier; capability token validated server-side before swap fires
- **Law #6** — RLS preserved (no policy changes; column inherits FORCE ROW LEVEL SECURITY)

## Test plan

- [x] pytest tests/routes/test_receptionist_personas.py — 12/12 pass
- [x] pytest tests/routes/test_front_desk.py — 8/8 pass (no regressions)
- [x] pytest tests/security/test_rls_front_desk_configs.py — 5/5 pass
- [x] pytest tests/integration/test_front_desk_sync_to_personalization.py — 9/9 pass
- [x] pytest tests/routes/test_telephony.py tests/routes/test_sarah_personalization.py — 29/29 pass
- [x] Migration 109 applied to production Supabase; RLS still relrowsecurity=true relforcerowsecurity=true
- [ ] Manual smoke after deploy: curl /v1/front-desk/personas returns Sarah + Tiffany
- [ ] Live inbound-call test: pick Tiffany, save, place test call, verify Tiffany answers in her voice

## Companion PR

Frontend: swayz032/Aspire-Desktop feat/receptionist-persona-picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)