### PR TITLE
fix(providers): URL-encode query params (ATTOM 400 hotfix — unblocks Adam)

### DIFF
--- a/orchestrator/src/aspire_orchestrator/providers/base_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/base_client.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 
@@ -299,10 +300,17 @@ class BaseProviderClient(ABC):
         # Build URL
         url = f"{self.base_url.rstrip('/')}{request.path}"
         if request.query_params:
-            qs = "&".join(
-                f"{k}={v}" for k, v in sorted(request.query_params.items())
-            )
-            url = f"{url}?{qs}"
+            # CRITICAL: use urlencode() to percent-encode spaces, commas, and
+            # other reserved characters in parameter values. The previous
+            # raw f-string concatenation produced URLs like
+            #   ...?address1=4863 Price St&address2=Forest Park, GA 30297
+            # which ATTOM (and most strict gateways) reject with HTTP 400
+            # INPUT_INVALID_FORMAT. urlencode() emits
+            #   ...?address1=4863+Price+St&address2=Forest+Park%2C+GA+30297
+            # which parses correctly. Verified end-to-end against ATTOM
+            # assessment/detail: unencoded → 400; encoded → 200 with full
+            # property record. Sorted for deterministic cache keys.
+            url = f"{url}?{urlencode(sorted(request.query_params.items()))}"
 
         # Get auth headers
         try:

--- a/orchestrator/tests/providers/test_base_client_url_encoding.py
+++ b/orchestrator/tests/providers/test_base_client_url_encoding.py
@@ -1,0 +1,128 @@
+"""Regression tests for base_client.py URL encoding.
+
+The bug this guards against: prior to commit fix/base-client-url-encoding,
+`BaseProviderClient._request()` built query strings via raw f-string
+concatenation, producing URLs with unencoded spaces / commas / reserved
+chars. ATTOM (and most strict gateways) reject those with HTTP 400
+INPUT_INVALID_FORMAT.
+
+Verified end-to-end against ATTOM `assessment/detail`:
+  - unencoded: HTTP 400 "Invalid Parameter(s) in Request"
+  - encoded:   HTTP 200 with full property record
+The fix uses `urllib.parse.urlencode(sorted(params.items()))`.
+
+These tests inspect the constructed URL via a stub httpx client and assert
+proper percent-encoding for the canonical failure inputs.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderRequest,
+)
+
+
+class _StubClient(BaseProviderClient):
+    """Minimal concrete subclass for URL-construction tests."""
+
+    provider_id = "stub"
+    base_url = "https://example.test"
+    timeout_seconds = 5.0
+    max_retries = 0
+
+    async def _authenticate_headers(self, _request: ProviderRequest) -> dict[str, str]:
+        return {"X-Stub-Auth": "1"}
+
+
+def _build_request(query_params: dict[str, str]) -> ProviderRequest:
+    return ProviderRequest(
+        method="GET",
+        path="/v1/property",
+        query_params=query_params,
+        correlation_id="test-corr-1",
+        suite_id="94b89098-c4bf-4419-a154-e18d9d53f993",
+        office_id="94b89098-c4bf-4419-a154-e18d9d53f993",
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_string_encodes_spaces(monkeypatch):
+    """Address with spaces must percent-encode (was: raw spaces → 400)."""
+    captured: dict[str, str] = {}
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
+        captured["url"] = url
+        return httpx.Response(200, json={"status": {"code": 0, "msg": "ok"}}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    client = _StubClient()
+    req = _build_request({"address1": "4863 Price St", "address2": "Forest Park, GA 30297"})
+    await client._request(req)
+
+    assert "url" in captured, "stubbed GET was never invoked"
+    # urlencode emits + for spaces (preferred for application/x-www-form-urlencoded
+    # style query strings) and %2C for comma.
+    assert "address1=4863+Price+St" in captured["url"]
+    assert "address2=Forest+Park%2C+GA+30297" in captured["url"]
+    assert " " not in captured["url"], "raw space leaked into URL"
+
+
+@pytest.mark.asyncio
+async def test_query_string_encodes_ampersand(monkeypatch):
+    """Ampersand in value must be %26 to avoid being parsed as param separator."""
+    captured: dict[str, str] = {}
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
+        captured["url"] = url
+        return httpx.Response(200, json={"status": {"code": 0, "msg": "ok"}}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    client = _StubClient()
+    req = _build_request({"owner": "Smith & Sons LLC"})
+    await client._request(req)
+
+    assert "owner=Smith+%26+Sons+LLC" in captured["url"]
+
+
+@pytest.mark.asyncio
+async def test_query_string_sorted_deterministic(monkeypatch):
+    """Params sorted alphabetically — guarantees deterministic cache keys."""
+    captured: dict[str, str] = {}
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
+        captured["url"] = url
+        return httpx.Response(200, json={"status": {"code": 0, "msg": "ok"}}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    client = _StubClient()
+    # Insertion order intentionally NOT alphabetical.
+    req = _build_request({"zip": "30297", "address1": "4863 Price St"})
+    await client._request(req)
+
+    qs = captured["url"].split("?", 1)[1]
+    # Alphabetical: address1 before zip.
+    assert qs.index("address1=") < qs.index("zip=")
+
+
+@pytest.mark.asyncio
+async def test_empty_query_params_no_question_mark(monkeypatch):
+    """No query params → no trailing `?` in URL."""
+    captured: dict[str, str] = {}
+
+    async def fake_get(self, url, **kwargs):  # noqa: ANN001 — test stub
+        captured["url"] = url
+        return httpx.Response(200, json={"status": {"code": 0, "msg": "ok"}}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    client = _StubClient()
+    req = _build_request({})
+    await client._request(req)
+
+    assert "?" not in captured["url"]


### PR DESCRIPTION
## TL;DR
Adam's `PROPERTY_FACTS_AND_PERMITS` playbook returns empty fields for every address because `base_client.py` builds query strings without URL encoding. ATTOM rejects every request with HTTP 400 `INPUT_INVALID_FORMAT`. This is a **one-line fix** plus 4 regression tests.

## Evidence

**Production logs (correlation_id `d861b8ac`, address `4863 Price St, Forest Park, GA 30297`):**
- 13 parallel ATTOM requests → all 400 INPUT_INVALID_FORMAT (~1100ms each)
- Apify Zillow → 200 OK with 15 photos (works because POST + JSON body)
- Adam swallows the 400s as \`SuccessWithoutResult\` → returns \`success: true\` with blank fields

**Direct reproduction:**
\`\`\`
# Adam's URL shape (raw spaces): curl rejects outright
$ curl '...assessment/detail?address1=4863 Price St&address2=Forest Park, GA 30297'
curl: (3) URL rejected: Malformed input to a URL function

# Same call URL-encoded: ATTOM returns full record
$ curl --data-urlencode 'address1=4863 Price St' --data-urlencode 'address2=Forest Park, GA 30297' -G '...'
HTTP 200 — yearbuilt 2012, 5bd/3ba/2635 sqft, owner-occupied SFR
\`\`\`

## Root cause

\`backend/orchestrator/src/aspire_orchestrator/providers/base_client.py:301-305\` (before this PR):
\`\`\`python
if request.query_params:
    qs = '&'.join(f'{k}={v}' for k, v in sorted(request.query_params.items()))
    url = f'{url}?{qs}'
\`\`\`
No encoding. Spaces, commas, ampersands all pass through raw.

## Fix

Replace with \`urllib.parse.urlencode()\`. One line, plus an inline comment documenting the failure mode for the next reader.

## Affected
- **ATTOM**: every endpoint (was the canary)
- Any other GET-based provider with spaces/commas/specials in params

Apify Zillow (POST + JSON), ElevenLabs, Twilio, Stripe etc. are unaffected — they don't pass strings with spaces through query params.

## Cache caveat
ATTOM responses are cached for 24h via process-local cache keyed on params. Existing cached "empty" responses persist until expiry. **Recommend bumping the cache version constant after deploy** to force a refresh, or accepting one day of stale empty results.

## Tests
\`tests/providers/test_base_client_url_encoding.py\` — 4 new tests:
1. Spaces in address values → \`+\` encoded
2. Comma in address → \`%2C\`
3. Ampersand in owner name → \`%26\` (not parsed as param separator)
4. Deterministic alphabetical sort + no trailing \`?\` when no params

## Pending gates (founder must complete)
- \`gate-1-testing-pending\` — run pytest:
  \`\`\`
  wsl -d Ubuntu-22.04 -e bash -c \"cd /mnt/c/Users/tonio/Projects/myapp/backend/orchestrator && source ~/venvs/aspire/bin/activate && python -m pytest tests/providers/test_base_client_url_encoding.py -q --tb=short\"
  \`\`\`
- \`gate-5-deploy-pending\` — \`railway up\` on \`Ava-Brain\` service after green tests

## Relationship to Phase B-1 PR #48
Independent. This is a P0 production hotfix; Phase B-1 is the reliability scaffolding follow-up. Merge order: this PR first (unblocks users today), then PR #48.