### PR TITLE
fix(attom): drop unsupported orderBy from poi_search v4

### DIFF
--- a/orchestrator/src/aspire_orchestrator/providers/attom_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/attom_client.py
@@ -1741,9 +1741,10 @@ async def execute_attom_poi_search(
     # entirely — V4 ignores it and we're now V4-only.
     params["radius"] = str(payload.get("radius") or 5)
     params["pageSize"] = str(payload.get("pageSize") or 50)
-    # Sort by distance ascending so closest POIs are first — guarantees a
-    # useful "near me" UX regardless of ATTOM's default ordering.
-    params["orderBy"] = str(payload.get("orderby") or "DISTANCE")
+    # ATTOM v4 /neighborhood/poi rejects `orderBy` as an invalid parameter
+    # (verified 2026-05-11: 200 OK without it, 400 "Invalid Parameter(s)
+    # in Request - ORDERBY" when included). v4 already returns POIs in
+    # distance order by default.
 
     # Default category whitelist drops 4 of the 14 ATTOM POI categories
     # (FARM-RANCH, AUTOMOTIVE SERVICES, PET SERVICES, ORGANIZATIONS-


### PR DESCRIPTION
## Root cause
PR #50 fixed the lowercase `orderby` -> `orderBy` casing in `poi_search` thinking ATTOM rejected only the case. Direct curl probe today proves ATTOM v4 `/neighborhood/poi` rejects `orderBy` **at all**:

```
WITH orderBy=DISTANCE   -> 400 'Invalid Parameter(s) in Request - ORDERBY'
WITHOUT orderBy         -> 200 SuccessWithResult total=7471 POIs
```

v4 returns POIs in distance order by default, so dropping the param gives the same UX without the rejection.

## Fix
Remove `params["orderBy"] = ...` line from `execute_attom_poi_search`.

## Scope
- `providers/attom_client.py:1746` only
- Other endpoints (sales_expanded_history, search filters via the mapping tuple) DO accept `orderBy` correctly and are unchanged.

## Verification
Live curl against ATTOM gateway with production API key, exact same address Adam uses for property research.