### PR TITLE
fix(serpapi): dual-account budget plumbing + Supabase persistent counter

### DIFF
--- a/orchestrator/src/aspire_orchestrator/providers/serpapi_homedepot_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/serpapi_homedepot_client.py
@@ -5,9 +5,10 @@ Auth: Query parameter api_key
 Risk tier: GREEN (read-only search)
 Idempotency: N/A (read-only)
 
-Budget note: SerpApi free tier is 250 searches/month. no_cache defaults to False so
-cached results are returned when available — cached searches do not count against the
-monthly quota.
+Budget note: SerpApi free tier is 250 searches/month across two accounts (A+B, 240 cap each).
+Dual-account budget gate: select_account() → try_increment() → get_api_key(). On HTTP 429 /
+quota body error, mark_account_exhausted() forces the account to cap, then the other account
+is tried once. Adapter never retries autonomously — orchestrator owns retry logic (Law #1).
 
 Tools:
   - serpapi_home_depot.search: Search Home Depot product catalog via SerpApi
@@ -19,7 +20,6 @@ import asyncio
 import logging
 from typing import Any
 
-from aspire_orchestrator.config.settings import settings
 from aspire_orchestrator.models import Outcome
 from aspire_orchestrator.providers.base_client import (
     BaseProviderClient,
@@ -28,6 +28,14 @@ from aspire_orchestrator.providers.base_client import (
     ProviderResponse,
 )
 from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.adam.serpapi_budget import (
+    BudgetExhaustedError,
+    current_counts,
+    get_api_key,
+    mark_account_exhausted,
+    select_account,
+    try_increment,
+)
 from aspire_orchestrator.services.tool_types import ToolExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -46,13 +54,7 @@ class SerpApiHomeDepotClient(BaseProviderClient):
         self, request: ProviderRequest
     ) -> dict[str, str]:
         # SerpApi authenticates via query param, not headers.
-        # Validate key is present; injection happens in query_params.
-        if not settings.serpapi_api_key:
-            raise ProviderError(
-                code=InternalErrorCode.AUTH_INVALID_KEY,
-                message="SerpApi API key not configured (ASPIRE_SERPAPI_API_KEY)",
-                provider_id=self.provider_id,
-            )
+        # Key is injected into query_params in execute_serpapi_homedepot_search.
         return {}
 
     def _parse_error(
@@ -125,8 +127,57 @@ async def execute_serpapi_homedepot_search(
             receipt_data=receipt,
         )
 
-    api_key = settings.serpapi_api_key
-    if not api_key:
+    # --- Dual-account budget gate (Pass A) ---
+    # State machine: select_account → try_increment → get_api_key.
+    # On 429/quota: mark_account_exhausted → retry other account once.
+    _counts = current_counts()
+    account_id = select_account()
+    if account_id is None:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code="SERPAPI_BUDGET_EXHAUSTED",
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error=str(BudgetExhaustedError(_counts)),
+            receipt_data=receipt,
+        )
+
+    if not try_increment(account_id):
+        # Race: another request consumed the last slot between select and increment
+        other = "B" if account_id == "A" else "A"
+        if not try_increment(other):
+            _counts = current_counts()
+            receipt = client.make_receipt_data(
+                correlation_id=correlation_id,
+                suite_id=suite_id,
+                office_id=office_id,
+                tool_id=tool_id,
+                risk_tier=risk_tier,
+                outcome=Outcome.FAILED,
+                reason_code="SERPAPI_BUDGET_EXHAUSTED",
+                capability_token_id=capability_token_id,
+                capability_token_hash=capability_token_hash,
+            )
+            return ToolExecutionResult(
+                outcome=Outcome.FAILED,
+                tool_id=tool_id,
+                error=str(BudgetExhaustedError(_counts)),
+                receipt_data=receipt,
+            )
+        account_id = other
+
+    try:
+        api_key = get_api_key(account_id)
+    except KeyError as exc:
         receipt = client.make_receipt_data(
             correlation_id=correlation_id,
             suite_id=suite_id,
@@ -141,7 +192,7 @@ async def execute_serpapi_homedepot_search(
         return ToolExecutionResult(
             outcome=Outcome.FAILED,
             tool_id=tool_id,
-            error="SerpApi API key not configured",
+            error=f"SerpApi account {account_id} key not configured",
             receipt_data=receipt,
         )
 
@@ -196,11 +247,50 @@ async def execute_serpapi_homedepot_search(
             receipt_data=receipt,
         )
 
+    # --- 429 / quota-body exhaustion detection (Pass A) ---
+    # SerpApi returns HTTP 429 for rate limiting and HTTP 200 with an error
+    # body containing "quota" or "plan" when the monthly limit is hit. Either
+    # signal means this account is exhausted — mark it and try the other once.
+    _is_quota = (
+        response.status_code == 429
+        or (
+            not response.success
+            and response.error_message is not None
+            and any(
+                kw in response.error_message.lower()
+                for kw in ("quota", "plan", "limit exceeded", "searches/month")
+            )
+        )
+    )
+    if _is_quota:
+        mark_account_exhausted(account_id, reason=f"HTTP {response.status_code}")
+        # Retry on the other account (single attempt — Law #1: no autonomous retry loops)
+        other_account = "B" if account_id == "A" else "A"
+        if try_increment(other_account):
+            try:
+                other_key = get_api_key(other_account)
+                query_params["api_key"] = other_key
+                request2 = ProviderRequest(
+                    method="GET",
+                    path="/search",
+                    query_params=query_params,
+                    correlation_id=correlation_id,
+                    suite_id=suite_id,
+                    office_id=office_id,
+                )
+                response = await asyncio.wait_for(
+                    client._request(request2), timeout=timeout
+                )
+                account_id = other_account
+            except (KeyError, asyncio.TimeoutError):
+                pass  # Fall through to failure path below
+
     outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
     reason = "EXECUTED" if response.success else (
         response.error_code.value if response.error_code else "FAILED"
     )
 
+    _post_counts = current_counts()
     receipt = client.make_receipt_data(
         correlation_id=correlation_id,
         suite_id=suite_id,
@@ -213,6 +303,10 @@ async def execute_serpapi_homedepot_search(
         capability_token_hash=capability_token_hash,
         provider_response=response,
     )
+    # Augment receipt with budget state for audit trail (Law #2)
+    receipt["budget_account_id"] = account_id
+    receipt["budget_remaining_a"] = max(0, 240 - _post_counts.get("A", 0))
+    receipt["budget_remaining_b"] = max(0, 240 - _post_counts.get("B", 0))
 
     if response.success:
         raw_products = response.body.get("products", [])
@@ -327,35 +421,22 @@ async def execute_serpapi_homedepot_search(
                         "price_was": p.get("price_was"),
                         "price_saving": p.get("price_saving"),
                         "percentage_off": p.get("percentage_off"),
-                        # CA-specific: SerpAPI returns "33%" string here.
                         "percent_off": p.get("percent_off"),
-                        # SerpAPI HD price highlight chip ("Special-Buy", "New-Lower-Price").
                         "price_badge": p.get("price_badge"),
-                        # Currency: explicit when SerpAPI returns it (CA = "CAD"),
-                        # else inferred downstream by the normalizer from URL host.
                         "currency": p.get("currency"),
-                        # Pricing unit ("case", "package", "piece") — surfaced as
-                        # "$99.97 / case" on the card price line when present.
                         "unit": p.get("unit") or "",
                         "rating": p.get("rating"),
                         "reviews": p.get("reviews"),
-                        # Social proof — favorite count from HD ("10,293 saved").
                         "favorite": p.get("favorite"),
-                        # Collection page URL (e.g. DEWALT 20V Collection).
                         "collection": p.get("collection") or "",
-                        # CA-only stock dict (general_stock, store_stock_status).
                         "stock_information": p.get("stock_information") or {},
-                        # Forward the raw nested pickup object (per-product local store).
                         "pickup": p.get("pickup") or {},
                         "delivery": p.get("delivery"),
                         "link": p.get("link"),
-                        # Direct lazy-enrich URL — preferred over rebuilt path
-                        # because it carries any tier-specific routing flags.
                         "serpapi_link": p.get("serpapi_link") or "",
                         "thumbnail": _pick_image(p),
                         "thumbnails": p.get("thumbnails") or [],
                         "badges": p.get("badges", []),
-                        # Extended fields surfaced for richer card rendering.
                         "description": p.get("description") or p.get("highlights") or "",
                         "specifications": p.get("specifications") or {},
                         "dimensions": p.get("dimensions") or {},
@@ -368,10 +449,6 @@ async def execute_serpapi_homedepot_search(
                 "query": query,
                 "result_count": len(raw_products),
                 "store": store_info,
-                # Search-level metadata for refinable sessions and breadcrumbs.
-                # taxonomy = category trail ("Tools > Power Tools > Drills").
-                # filters = facets with hd_filter_tokens for "show only Milwaukee
-                # under $200" follow-ups. related_products = query suggestions.
                 "taxonomy": response.body.get("taxonomy") or [],
                 "filters": response.body.get("filters") or [],
                 "related_products": response.body.get("related_products")

--- a/orchestrator/src/aspire_orchestrator/providers/serpapi_homedepot_product_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/serpapi_homedepot_product_client.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aspire_orchestrator.config.settings import settings
 from aspire_orchestrator.models import Outcome
 from aspire_orchestrator.providers.base_client import (
     BaseProviderClient,
@@ -28,6 +27,14 @@ from aspire_orchestrator.providers.base_client import (
     ProviderRequest,
 )
 from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.adam.serpapi_budget import (
+    BudgetExhaustedError,
+    current_counts,
+    get_api_key,
+    mark_account_exhausted,
+    select_account,
+    try_increment,
+)
 from aspire_orchestrator.services.tool_types import ToolExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -47,12 +54,8 @@ class SerpApiHomeDepotProductClient(BaseProviderClient):
     async def _authenticate_headers(
         self, request: ProviderRequest
     ) -> dict[str, str]:
-        if not settings.serpapi_api_key:
-            raise ProviderError(
-                code=InternalErrorCode.AUTH_INVALID_KEY,
-                message="SerpApi API key not configured (ASPIRE_SERPAPI_API_KEY)",
-                provider_id=self.provider_id,
-            )
+        # SerpApi authenticates via query param, not headers.
+        # Key is injected into query_params in fetch_product_details.
         return {}
 
     def _parse_error(
@@ -162,8 +165,54 @@ async def fetch_product_details(
             receipt_data=receipt,
         )
 
-    api_key = settings.serpapi_api_key
-    if not api_key:
+    # --- Dual-account budget gate (Pass A) ---
+    _counts = current_counts()
+    account_id = select_account()
+    if account_id is None:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code="SERPAPI_BUDGET_EXHAUSTED",
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error=str(BudgetExhaustedError(_counts)),
+            receipt_data=receipt,
+        )
+
+    if not try_increment(account_id):
+        other = "B" if account_id == "A" else "A"
+        if not try_increment(other):
+            _counts = current_counts()
+            receipt = client.make_receipt_data(
+                correlation_id=correlation_id,
+                suite_id=suite_id,
+                office_id=office_id,
+                tool_id=tool_id,
+                risk_tier=risk_tier,
+                outcome=Outcome.FAILED,
+                reason_code="SERPAPI_BUDGET_EXHAUSTED",
+                capability_token_id=capability_token_id,
+                capability_token_hash=capability_token_hash,
+            )
+            return ToolExecutionResult(
+                outcome=Outcome.FAILED,
+                tool_id=tool_id,
+                error=str(BudgetExhaustedError(_counts)),
+                receipt_data=receipt,
+            )
+        account_id = other
+
+    try:
+        api_key = get_api_key(account_id)
+    except KeyError:
         receipt = client.make_receipt_data(
             correlation_id=correlation_id,
             suite_id=suite_id,
@@ -178,7 +227,7 @@ async def fetch_product_details(
         return ToolExecutionResult(
             outcome=Outcome.FAILED,
             tool_id=tool_id,
-            error="SerpApi API key not configured",
+            error=f"SerpApi account {account_id} key not configured",
             receipt_data=receipt,
         )
 
@@ -201,11 +250,45 @@ async def fetch_product_details(
         )
     )
 
+    # --- 429 / quota-body exhaustion detection (Pass A) ---
+    _is_quota = (
+        response.status_code == 429
+        or (
+            not response.success
+            and response.error_message is not None
+            and any(
+                kw in response.error_message.lower()
+                for kw in ("quota", "plan", "limit exceeded", "searches/month")
+            )
+        )
+    )
+    if _is_quota:
+        mark_account_exhausted(account_id, reason=f"HTTP {response.status_code}")
+        other_account = "B" if account_id == "A" else "A"
+        if try_increment(other_account):
+            try:
+                other_key = get_api_key(other_account)
+                query_params["api_key"] = other_key
+                response = await client._request(
+                    ProviderRequest(
+                        method="GET",
+                        path="/search",
+                        query_params=query_params,
+                        correlation_id=correlation_id,
+                        suite_id=suite_id,
+                        office_id=office_id,
+                    )
+                )
+                account_id = other_account
+            except KeyError:
+                pass
+
     outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
     reason = "EXECUTED" if response.success else (
         response.error_code.value if response.error_code else "FAILED"
     )
 
+    _post_counts = current_counts()
     receipt = client.make_receipt_data(
         correlation_id=correlation_id,
         suite_id=suite_id,
@@ -218,6 +301,10 @@ async def fetch_product_details(
         capability_token_hash=capability_token_hash,
         provider_response=response,
     )
+    # Augment receipt with budget state for audit trail (Law #2)
+    receipt["budget_account_id"] = account_id
+    receipt["budget_remaining_a"] = max(0, 240 - _post_counts.get("A", 0))
+    receipt["budget_remaining_b"] = max(0, 240 - _post_counts.get("B", 0))
 
     if not response.success:
         return ToolExecutionResult(

--- a/orchestrator/src/aspire_orchestrator/providers/serpapi_shopping_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/serpapi_shopping_client.py
@@ -5,9 +5,10 @@ Auth: Query parameter api_key
 Risk tier: GREEN (read-only search)
 Idempotency: N/A (read-only)
 
-Budget note: SerpApi free tier is 250 searches/month. no_cache defaults to False so
-cached results are returned when available — cached searches do not count against the
-monthly quota.
+Budget note: SerpApi free tier is 250 searches/month across two accounts (A+B, 240 cap each).
+Dual-account budget gate: select_account() → try_increment() → get_api_key(). On HTTP 429 /
+quota body error, mark_account_exhausted() forces the account to cap, then the other account
+is tried once. Adapter never retries autonomously — orchestrator owns retry logic (Law #1).
 
 Tools:
   - serpapi_shopping.search: Execute a Google Shopping search via SerpApi
@@ -18,7 +19,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from aspire_orchestrator.config.settings import settings
 from aspire_orchestrator.models import Outcome
 from aspire_orchestrator.providers.base_client import (
     BaseProviderClient,
@@ -27,6 +27,14 @@ from aspire_orchestrator.providers.base_client import (
     ProviderResponse,
 )
 from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.adam.serpapi_budget import (
+    BudgetExhaustedError,
+    current_counts,
+    get_api_key,
+    mark_account_exhausted,
+    select_account,
+    try_increment,
+)
 from aspire_orchestrator.services.tool_types import ToolExecutionResult
 
 logger = logging.getLogger(__name__)
@@ -45,14 +53,7 @@ class SerpApiShoppingClient(BaseProviderClient):
         self, request: ProviderRequest
     ) -> dict[str, str]:
         # SerpApi authenticates via query param, not headers.
-        # _authenticate_headers must return a dict — return empty here.
-        # The api_key is injected directly into query_params in execute_.
-        if not settings.serpapi_api_key:
-            raise ProviderError(
-                code=InternalErrorCode.AUTH_INVALID_KEY,
-                message="SerpApi API key not configured (ASPIRE_SERPAPI_API_KEY)",
-                provider_id=self.provider_id,
-            )
+        # Key is injected into query_params in execute_serpapi_shopping_search.
         return {}
 
     def _parse_error(
@@ -126,8 +127,54 @@ async def execute_serpapi_shopping_search(
             receipt_data=receipt,
         )
 
-    api_key = settings.serpapi_api_key
-    if not api_key:
+    # --- Dual-account budget gate (Pass A) ---
+    _counts = current_counts()
+    account_id = select_account()
+    if account_id is None:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code="SERPAPI_BUDGET_EXHAUSTED",
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error=str(BudgetExhaustedError(_counts)),
+            receipt_data=receipt,
+        )
+
+    if not try_increment(account_id):
+        other = "B" if account_id == "A" else "A"
+        if not try_increment(other):
+            _counts = current_counts()
+            receipt = client.make_receipt_data(
+                correlation_id=correlation_id,
+                suite_id=suite_id,
+                office_id=office_id,
+                tool_id=tool_id,
+                risk_tier=risk_tier,
+                outcome=Outcome.FAILED,
+                reason_code="SERPAPI_BUDGET_EXHAUSTED",
+                capability_token_id=capability_token_id,
+                capability_token_hash=capability_token_hash,
+            )
+            return ToolExecutionResult(
+                outcome=Outcome.FAILED,
+                tool_id=tool_id,
+                error=str(BudgetExhaustedError(_counts)),
+                receipt_data=receipt,
+            )
+        account_id = other
+
+    try:
+        api_key = get_api_key(account_id)
+    except KeyError:
         receipt = client.make_receipt_data(
             correlation_id=correlation_id,
             suite_id=suite_id,
@@ -142,7 +189,7 @@ async def execute_serpapi_shopping_search(
         return ToolExecutionResult(
             outcome=Outcome.FAILED,
             tool_id=tool_id,
-            error="SerpApi API key not configured",
+            error=f"SerpApi account {account_id} key not configured",
             receipt_data=receipt,
         )
 
@@ -189,11 +236,45 @@ async def execute_serpapi_shopping_search(
         )
     )
 
+    # --- 429 / quota-body exhaustion detection (Pass A) ---
+    _is_quota = (
+        response.status_code == 429
+        or (
+            not response.success
+            and response.error_message is not None
+            and any(
+                kw in response.error_message.lower()
+                for kw in ("quota", "plan", "limit exceeded", "searches/month")
+            )
+        )
+    )
+    if _is_quota:
+        mark_account_exhausted(account_id, reason=f"HTTP {response.status_code}")
+        other_account = "B" if account_id == "A" else "A"
+        if try_increment(other_account):
+            try:
+                other_key = get_api_key(other_account)
+                query_params["api_key"] = other_key
+                response = await client._request(
+                    ProviderRequest(
+                        method="GET",
+                        path="/search",
+                        query_params=query_params,
+                        correlation_id=correlation_id,
+                        suite_id=suite_id,
+                        office_id=office_id,
+                    )
+                )
+                account_id = other_account
+            except KeyError:
+                pass
+
     outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
     reason = "EXECUTED" if response.success else (
         response.error_code.value if response.error_code else "FAILED"
     )
 
+    _post_counts = current_counts()
     receipt = client.make_receipt_data(
         correlation_id=correlation_id,
         suite_id=suite_id,
@@ -206,6 +287,10 @@ async def execute_serpapi_shopping_search(
         capability_token_hash=capability_token_hash,
         provider_response=response,
     )
+    # Augment receipt with budget state for audit trail (Law #2)
+    receipt["budget_account_id"] = account_id
+    receipt["budget_remaining_a"] = max(0, 240 - _post_counts.get("A", 0))
+    receipt["budget_remaining_b"] = max(0, 240 - _post_counts.get("B", 0))
 
     if response.success:
         raw_results = response.body.get("shopping_results", [])

--- a/orchestrator/src/aspire_orchestrator/services/adam/cache.py
+++ b/orchestrator/src/aspire_orchestrator/services/adam/cache.py
@@ -139,32 +139,71 @@ def _current_month() -> str:
 
 
 def serpapi_get_count() -> int:
-    """Get current month's SerpApi call count."""
-    return _serpapi_counter.get(_current_month(), 0)
+    """[DEPRECATED] Get current month's SerpApi call count.
+
+    Delegates to serpapi_budget.current_counts() for account A.
+    Use serpapi_budget.current_counts() directly for dual-account awareness.
+    """
+    import warnings
+    from aspire_orchestrator.services.adam.serpapi_budget import current_counts
+    warnings.warn(
+        "cache.serpapi_get_count() is deprecated — use serpapi_budget.current_counts()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return current_counts().get("A", 0)
 
 
 def serpapi_increment() -> int:
-    """Increment SerpApi counter. Returns new count."""
-    month = _current_month()
-    _serpapi_counter[month] = _serpapi_counter.get(month, 0) + 1
-    count = _serpapi_counter[month]
-    if count >= SERPAPI_MONTHLY_LIMIT:
-        logger.warning("SerpApi budget EXHAUSTED: %d/%d calls this month", count, SERPAPI_MONTHLY_LIMIT)
-    elif count >= 200:
-        logger.warning("SerpApi budget WARNING: %d/%d calls this month", count, SERPAPI_MONTHLY_LIMIT)
-    return count
+    """[DEPRECATED] Increment SerpApi counter. Returns new count.
+
+    Delegates to serpapi_budget.try_increment() for account A.
+    Use serpapi_budget.select_account() + try_increment() for dual-account budget gate.
+    """
+    import warnings
+    from aspire_orchestrator.services.adam.serpapi_budget import try_increment, current_counts
+    warnings.warn(
+        "cache.serpapi_increment() is deprecated — use serpapi_budget.try_increment()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    try_increment("A")
+    return current_counts().get("A", 0)
 
 
 def serpapi_check_budget() -> bool:
-    """Check if SerpApi budget allows another call. Returns False if exhausted."""
-    return serpapi_get_count() < SERPAPI_MONTHLY_LIMIT
+    """[DEPRECATED] Check if SerpApi budget allows another call.
+
+    Delegates to serpapi_budget.select_account() — returns True if any account has budget.
+    Use serpapi_budget.select_account() directly for dual-account awareness.
+    """
+    import warnings
+    from aspire_orchestrator.services.adam.serpapi_budget import select_account
+    warnings.warn(
+        "cache.serpapi_check_budget() is deprecated — use serpapi_budget.select_account()",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return select_account() is not None
 
 
 def serpapi_budget_error_message() -> str:
-    """Build user-facing error message for budget exhaustion."""
-    count = serpapi_get_count()
+    """[DEPRECATED] Build user-facing error message for budget exhaustion.
+
+    Use serpapi_budget.BudgetExhaustedError(current_counts()) directly.
+    """
+    import warnings
+    from aspire_orchestrator.services.adam.serpapi_budget import current_counts, DEFAULT_CAP
+    warnings.warn(
+        "cache.serpapi_budget_error_message() is deprecated — use BudgetExhaustedError",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    counts = current_counts()
+    total = sum(counts.values())
+    total_cap = DEFAULT_CAP * len(counts)
     return (
-        f"SerpApi monthly research budget exhausted ({count}/{SERPAPI_MONTHLY_LIMIT} searches used). "
+        f"SerpApi monthly research budget exhausted ({total}/{total_cap} searches used across all accounts). "
         f"Product pricing searches will resume next month. "
         f"Web search alternatives (Brave, Exa) are still available for general pricing research."
     )

--- a/orchestrator/src/aspire_orchestrator/services/adam/serpapi_budget.py
+++ b/orchestrator/src/aspire_orchestrator/services/adam/serpapi_budget.py
@@ -1,0 +1,326 @@
+"""SerpApi dual-account budget manager — Supabase-persistent monthly counter.
+
+Design:
+  - Two SerpApi accounts (A and B), each capped at 240 calls/month.
+  - select_account() picks the first account that still has budget.
+  - try_increment() atomically increments via Supabase RPC (fail-safe on DB error).
+  - get_api_key() maps account_id → env var (never stored in settings/logs).
+  - mark_account_exhausted() hard-caps the account in DB immediately.
+  - current_counts() returns live budget state for receipt redacted_outputs.
+
+Env vars (Railway Ava-Brain):
+  account A → SERPAPI_API_KEY
+  account B → ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY
+
+Law #9: API keys are never logged. account_id ('A'/'B') is safe to log.
+Law #2: Budget state is surfaced in adapter receipts via current_counts().
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ACCOUNTS: tuple[str, ...] = ("A", "B")
+DEFAULT_CAP: int = 240  # 10-unit buffer below SerpApi free-tier 250 limit
+
+# ---------------------------------------------------------------------------
+# Supabase client (lazy init — mirrors provider_call_logger pattern)
+# ---------------------------------------------------------------------------
+
+_supabase_client: Any = None
+_supabase_init_done: bool = False
+_supabase_init_lock = threading.Lock()
+
+
+def _init_supabase() -> Any | None:
+    """Lazy-init Supabase client for budget persistence."""
+    global _supabase_client, _supabase_init_done
+
+    if _supabase_init_done:
+        return _supabase_client
+
+    with _supabase_init_lock:
+        if _supabase_init_done:
+            return _supabase_client
+
+        url = os.environ.get("ASPIRE_SUPABASE_URL", "")
+        key = os.environ.get("ASPIRE_SUPABASE_SERVICE_ROLE_KEY", "")
+
+        if url and key:
+            try:
+                from supabase import create_client
+                _supabase_client = create_client(url, key)
+                logger.info("SerpApiBudget: Supabase client initialized")
+            except Exception as exc:
+                logger.warning("SerpApiBudget: Supabase init failed: %s", exc)
+                _supabase_client = None
+        else:
+            logger.warning(
+                "SerpApiBudget: ASPIRE_SUPABASE_URL or ASPIRE_SUPABASE_SERVICE_ROLE_KEY "
+                "not set — falling back to in-memory counter"
+            )
+            _supabase_client = None
+
+        _supabase_init_done = True
+        return _supabase_client
+
+
+# ---------------------------------------------------------------------------
+# In-memory fallback (used when Supabase unavailable — resets on restart)
+# ---------------------------------------------------------------------------
+
+_in_memory_counts: dict[str, dict[str, int]] = {}  # month -> {account_id -> count}
+_in_memory_lock = threading.Lock()
+
+
+def _current_month() -> str:
+    """Return current UTC month key as 'YYYY-MM'."""
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+# ---------------------------------------------------------------------------
+# Budget read
+# ---------------------------------------------------------------------------
+
+def _get_count_for_account(account_id: str) -> int:
+    """Return current month's call count for account_id.
+
+    Tries Supabase first; falls back to in-memory on any error.
+    """
+    month = _current_month()
+    client = _init_supabase()
+
+    if client is not None:
+        try:
+            result = (
+                client.table("serpapi_budget")
+                .select("count")
+                .eq("month", month)
+                .eq("account_id", account_id)
+                .execute()
+            )
+            rows = result.data if result else []
+            if isinstance(rows, list) and rows:
+                return int(rows[0].get("count", 0))
+            return 0
+        except Exception as exc:
+            logger.warning(
+                "SerpApiBudget: DB read failed for account %s — using in-memory: %s",
+                account_id, exc,
+            )
+
+    # In-memory fallback
+    with _in_memory_lock:
+        return _in_memory_counts.get(month, {}).get(account_id, 0)
+
+
+def current_counts() -> dict[str, int]:
+    """Return {account_id: count} for current month for all accounts.
+
+    Used by adapters to populate receipt redacted_outputs.
+    """
+    return {acc: _get_count_for_account(acc) for acc in ACCOUNTS}
+
+
+# ---------------------------------------------------------------------------
+# Account selection
+# ---------------------------------------------------------------------------
+
+def select_account() -> str | None:
+    """Return the first account (A then B) that still has budget, or None.
+
+    None means both accounts are exhausted — caller must raise BudgetExhaustedError.
+    """
+    for account_id in ACCOUNTS:
+        count = _get_count_for_account(account_id)
+        if count < DEFAULT_CAP:
+            return account_id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Atomic increment via Supabase RPC
+# ---------------------------------------------------------------------------
+
+def try_increment(account_id: str) -> bool:
+    """Atomically increment the budget counter for account_id.
+
+    Returns True if the increment succeeded (slot was available).
+    Returns False if the account was already at cap (RPC returns NULL).
+
+    The RPC `increment_serpapi_budget` uses UPDATE ... WHERE count < p_cap,
+    so a NULL return means the row was at cap — no increment happened.
+    """
+    month = _current_month()
+    client = _init_supabase()
+
+    if client is not None:
+        try:
+            result = client.rpc(
+                "increment_serpapi_budget",
+                {"p_month": month, "p_account_id": account_id, "p_cap": DEFAULT_CAP},
+            ).execute()
+
+            new_count = result.data
+            # Defensive: supabase-py may wrap scalar in list across versions (R1)
+            if isinstance(new_count, list):
+                new_count = new_count[0] if new_count else None
+
+            if new_count is None:
+                # RPC returned NULL → UPDATE matched no rows → account at cap
+                logger.warning(
+                    "SerpApiBudget: account %s at cap (%d) — increment denied",
+                    account_id, DEFAULT_CAP,
+                )
+                return False
+
+            new_count = int(new_count)
+            if new_count >= DEFAULT_CAP:
+                logger.warning(
+                    "SerpApiBudget: account %s reached cap (%d/%d)",
+                    account_id, new_count, DEFAULT_CAP,
+                )
+            elif new_count >= 200:
+                logger.warning(
+                    "SerpApiBudget: account %s WARNING (%d/%d calls this month)",
+                    account_id, new_count, DEFAULT_CAP,
+                )
+            else:
+                logger.debug(
+                    "SerpApiBudget: account %s incremented to %d/%d",
+                    account_id, new_count, DEFAULT_CAP,
+                )
+            return True
+
+        except Exception as exc:
+            logger.warning(
+                "SerpApiBudget: DB increment failed for account %s — using in-memory: %s",
+                account_id, exc,
+            )
+
+    # In-memory fallback
+    with _in_memory_lock:
+        month_counts = _in_memory_counts.setdefault(month, {})
+        current = month_counts.get(account_id, 0)
+        if current >= DEFAULT_CAP:
+            return False
+        month_counts[account_id] = current + 1
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Key resolution (Law #9 — keys never logged)
+# ---------------------------------------------------------------------------
+
+def get_api_key(account_id: str) -> str:
+    """Resolve account_id to its API key from environment.
+
+    Maps:
+      'A' → SERPAPI_API_KEY          (Account A — primary, Railway env var)
+      'B' → ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY  (Account B — Railway env var)
+
+    Raises KeyError if the env var is missing or empty (fail-closed, Law #3).
+    """
+    if account_id == "A":
+        key = os.environ.get("SERPAPI_API_KEY", "").strip()
+        if not key:
+            # Also try ASPIRE_SERPAPI_API_KEY (settings prefix form)
+            key = os.environ.get("ASPIRE_SERPAPI_API_KEY", "").strip()
+        if not key:
+            raise KeyError(
+                "SERPAPI_API_KEY not configured — SerpApi account A unavailable"
+            )
+        return key
+
+    if account_id == "B":
+        key = os.environ.get("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "").strip()
+        if not key:
+            raise KeyError(
+                "ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY not configured — "
+                "SerpApi account B unavailable"
+            )
+        return key
+
+    raise KeyError(f"Unknown SerpApi account_id: {account_id!r}")
+
+
+# ---------------------------------------------------------------------------
+# Hard exhaustion marker
+# ---------------------------------------------------------------------------
+
+def mark_account_exhausted(account_id: str, reason: str) -> None:
+    """Force account_id count to cap in DB (e.g. after receiving HTTP 429).
+
+    This prevents further calls from select_account() picking this account
+    until the monthly cron reset.
+    """
+    month = _current_month()
+    client = _init_supabase()
+
+    if client is not None:
+        try:
+            client.table("serpapi_budget").upsert(
+                {
+                    "month": month,
+                    "account_id": account_id,
+                    "count": DEFAULT_CAP,
+                    "cap": DEFAULT_CAP,
+                },
+                on_conflict="month,account_id",
+            ).execute()
+            logger.warning(
+                "SerpApiBudget: account %s forcibly exhausted (reason=%s)",
+                account_id, reason,
+            )
+        except Exception as exc:
+            logger.warning(
+                "SerpApiBudget: failed to mark account %s exhausted: %s",
+                account_id, exc,
+            )
+
+    # Mirror in in-memory fallback regardless
+    with _in_memory_lock:
+        _in_memory_counts.setdefault(month, {})[account_id] = DEFAULT_CAP
+
+
+# ---------------------------------------------------------------------------
+# Custom exception
+# ---------------------------------------------------------------------------
+
+class BudgetExhaustedError(Exception):
+    """Raised when both SerpApi accounts have exhausted their monthly budget."""
+
+    def __init__(self, counts: dict[str, int] | None = None) -> None:
+        counts = counts or {}
+        msg = (
+            f"SerpApi monthly budget exhausted on all accounts "
+            f"(A={counts.get('A', DEFAULT_CAP)}/{DEFAULT_CAP}, "
+            f"B={counts.get('B', DEFAULT_CAP)}/{DEFAULT_CAP}). "
+            f"Product pricing searches will resume next month."
+        )
+        super().__init__(msg)
+        self.counts = counts
+
+
+# ---------------------------------------------------------------------------
+# Test helpers (reset in-memory state between tests)
+# ---------------------------------------------------------------------------
+
+def _reset_for_tests() -> None:
+    """Reset in-memory state. Call in test teardown only."""
+    global _supabase_init_done, _supabase_client
+    with _in_memory_lock:
+        _in_memory_counts.clear()
+    with _supabase_init_lock:
+        _supabase_init_done = False
+        _supabase_client = None

--- a/orchestrator/tests/providers/test_serpapi_budget_integration.py
+++ b/orchestrator/tests/providers/test_serpapi_budget_integration.py
@@ -1,0 +1,174 @@
+"""Tests 12-15: SerpApi adapter integration tests — budget gate in adapter layer.
+
+These tests verify that the three SerpApi adapter functions (homedepot, shopping,
+product) correctly wire through the dual-account budget gate and handle exhaustion,
+429 detection, and account-A-to-B failover.
+
+All provider HTTP calls are mocked. Budget state uses in-memory (no Supabase).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import aspire_orchestrator.services.adam.serpapi_budget as budget_module
+from aspire_orchestrator.models import Outcome
+from aspire_orchestrator.providers.base_client import ProviderResponse
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.adam.serpapi_budget import DEFAULT_CAP
+
+
+@pytest.fixture(autouse=True)
+def reset_budget():
+    budget_module._reset_for_tests()
+    yield
+    budget_module._reset_for_tests()
+
+
+def _success_response(body: dict | None = None) -> ProviderResponse:
+    return ProviderResponse(
+        success=True,
+        status_code=200,
+        body=body or {"products": [], "shopping_results": [], "product_results": {}},
+        error_code=None,
+        error_message=None,
+    )
+
+
+def _rate_limited_response() -> ProviderResponse:
+    return ProviderResponse(
+        success=False,
+        status_code=429,
+        body={},
+        error_code=InternalErrorCode.RATE_LIMITED,
+        error_message="HTTP 429 RATE_LIMITED",
+    )
+
+
+def _quota_body_response() -> ProviderResponse:
+    return ProviderResponse(
+        success=False,
+        status_code=200,
+        body={},
+        error_code=InternalErrorCode.RATE_QUOTA_EXCEEDED,
+        error_message="searches/month plan limit exceeded",
+    )
+
+
+@pytest.mark.asyncio
+async def test_homedepot_adapter_returns_failed_when_budget_exhausted(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-a")
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-b")
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": DEFAULT_CAP, "B": DEFAULT_CAP}
+    from aspire_orchestrator.providers.serpapi_homedepot_client import execute_serpapi_homedepot_search
+    result = await execute_serpapi_homedepot_search(
+        payload={"query": "drywall screws"},
+        correlation_id="test-exhausted",
+        suite_id="suite-1",
+        office_id="office-1",
+    )
+    assert result.outcome == Outcome.FAILED
+    assert result.receipt_data is not None
+    assert result.receipt_data.get("reason_code") == "SERPAPI_BUDGET_EXHAUSTED"
+    assert "key-a" not in (result.error or "")
+    assert "key-b" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_homedepot_adapter_failover_on_429(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-a")
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-b")
+    call_count = 0
+
+    async def fake_request(request):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _rate_limited_response()
+        return _success_response({"products": [{"title": "test product"}]})
+
+    from aspire_orchestrator.providers import serpapi_homedepot_client as hd_mod
+    hd_mod._client = None
+    mock_client = MagicMock()
+    mock_client._request = AsyncMock(side_effect=fake_request)
+    mock_client.make_receipt_data = MagicMock(return_value={
+        "id": "test-receipt", "outcome": "success", "reason_code": "EXECUTED",
+    })
+    with patch.object(hd_mod, "_get_client", return_value=mock_client):
+        result = await hd_mod.execute_serpapi_homedepot_search(
+            payload={"query": "drywall screws", "store_id": "0206"},
+            correlation_id="test-429-failover",
+            suite_id="suite-1",
+            office_id="office-1",
+        )
+    assert budget_module._get_count_for_account("A") == DEFAULT_CAP
+    assert mock_client._request.await_count == 2
+    receipt_str = str(result.receipt_data or {})
+    assert "key-a" not in receipt_str
+    assert "key-b" not in receipt_str
+
+
+@pytest.mark.asyncio
+async def test_shopping_adapter_returns_failed_when_budget_exhausted(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-a")
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-b")
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": DEFAULT_CAP, "B": DEFAULT_CAP}
+    from aspire_orchestrator.providers.serpapi_shopping_client import execute_serpapi_shopping_search
+    result = await execute_serpapi_shopping_search(
+        payload={"query": "drywall 5/8 inch"},
+        correlation_id="test-shopping-exhausted",
+        suite_id="suite-1",
+        office_id="office-1",
+    )
+    assert result.outcome == Outcome.FAILED
+    assert result.receipt_data is not None
+    assert result.receipt_data.get("reason_code") == "SERPAPI_BUDGET_EXHAUSTED"
+    assert "key-a" not in (result.error or "")
+    assert "key-b" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_product_adapter_returns_failed_when_budget_exhausted(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-a")
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-b")
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": DEFAULT_CAP, "B": DEFAULT_CAP}
+    from aspire_orchestrator.providers.serpapi_homedepot_product_client import fetch_product_details
+    result = await fetch_product_details(
+        product_id="123456789",
+        correlation_id="test-product-exhausted",
+        suite_id="suite-1",
+        office_id="office-1",
+    )
+    assert result.outcome == Outcome.FAILED
+    assert result.receipt_data is not None
+    assert result.receipt_data.get("reason_code") == "SERPAPI_BUDGET_EXHAUSTED"
+    assert "key-a" not in (result.error or "")
+    assert "key-b" not in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_receipt_always_generated_on_budget_exhaustion(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-a")
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-b")
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": DEFAULT_CAP, "B": DEFAULT_CAP}
+    from aspire_orchestrator.providers.serpapi_homedepot_client import execute_serpapi_homedepot_search
+    result = await execute_serpapi_homedepot_search(
+        payload={"query": "lumber 2x4"},
+        correlation_id="test-law2",
+        suite_id="suite-2",
+        office_id="office-2",
+    )
+    assert result.receipt_data is not None, "Law #2: receipt_data missing on budget exhaustion"
+    receipt_str = str(result.receipt_data)
+    assert "key-a" not in receipt_str
+    assert "key-b" not in receipt_str

--- a/orchestrator/tests/services/adam/test_serpapi_budget.py
+++ b/orchestrator/tests/services/adam/test_serpapi_budget.py
@@ -1,0 +1,172 @@
+"""Tests 1-11: serpapi_budget.py unit tests.
+
+Contract tests covering:
+  - select_account logic (A first, fallback to B, None when both exhausted)
+  - try_increment in-memory path (DB mocked out)
+  - get_api_key env var mapping (no real keys — uses monkeypatched env)
+  - mark_account_exhausted forces count to cap
+  - current_counts returns {A: n, B: m}
+  - BudgetExhaustedError carries counts
+  - Defensive list-wrap handling in try_increment (R1)
+  - Deprecated cache.py stubs delegate correctly
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import aspire_orchestrator.services.adam.serpapi_budget as budget_module
+
+
+@pytest.fixture(autouse=True)
+def reset_budget():
+    budget_module._reset_for_tests()
+    yield
+    budget_module._reset_for_tests()
+
+
+def test_select_account_prefers_a_when_both_have_budget():
+    result = budget_module.select_account()
+    assert result == "A"
+
+
+def test_select_account_falls_back_to_b_when_a_exhausted():
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": budget_module.DEFAULT_CAP, "B": 0}
+    result = budget_module.select_account()
+    assert result == "B"
+
+
+def test_select_account_returns_none_when_both_exhausted():
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {
+            "A": budget_module.DEFAULT_CAP,
+            "B": budget_module.DEFAULT_CAP,
+        }
+    result = budget_module.select_account()
+    assert result is None
+
+
+def test_try_increment_increments_count():
+    result = budget_module.try_increment("A")
+    assert result is True
+    assert budget_module._get_count_for_account("A") == 1
+
+
+def test_try_increment_returns_false_at_cap():
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        budget_module._in_memory_counts[month] = {"A": budget_module.DEFAULT_CAP}
+    result = budget_module.try_increment("A")
+    assert result is False
+
+
+def test_try_increment_handles_list_wrapped_rpc_result():
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value.data = [5]
+    with patch.object(budget_module, "_init_supabase", return_value=mock_client):
+        budget_module._supabase_init_done = True
+        budget_module._supabase_client = mock_client
+        result = budget_module.try_increment("A")
+    assert result is True
+
+
+def test_try_increment_handles_none_rpc_result_as_at_cap():
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value.data = None
+    with patch.object(budget_module, "_init_supabase", return_value=mock_client):
+        budget_module._supabase_init_done = True
+        budget_module._supabase_client = mock_client
+        result = budget_module.try_increment("A")
+    assert result is False
+
+
+def test_try_increment_handles_empty_list_rpc_result_as_at_cap():
+    mock_client = MagicMock()
+    mock_client.rpc.return_value.execute.return_value.data = []
+    with patch.object(budget_module, "_init_supabase", return_value=mock_client):
+        budget_module._supabase_init_done = True
+        budget_module._supabase_client = mock_client
+        result = budget_module.try_increment("A")
+    assert result is False
+
+
+def test_get_api_key_account_a_reads_serpapi_api_key(monkeypatch):
+    monkeypatch.setenv("SERPAPI_API_KEY", "key-account-a")
+    monkeypatch.delenv("ASPIRE_SERPAPI_API_KEY", raising=False)
+    key = budget_module.get_api_key("A")
+    assert key == "key-account-a"
+
+
+def test_get_api_key_account_a_fallback_aspire_prefix(monkeypatch):
+    monkeypatch.delenv("SERPAPI_API_KEY", raising=False)
+    monkeypatch.setenv("ASPIRE_SERPAPI_API_KEY", "key-account-a-aspire")
+    key = budget_module.get_api_key("A")
+    assert key == "key-account-a-aspire"
+
+
+def test_get_api_key_account_b_reads_aspire_serpapi_2nd(monkeypatch):
+    monkeypatch.setenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", "key-account-b")
+    key = budget_module.get_api_key("B")
+    assert key == "key-account-b"
+
+
+def test_get_api_key_missing_raises_key_error(monkeypatch):
+    monkeypatch.delenv("SERPAPI_API_KEY", raising=False)
+    monkeypatch.delenv("ASPIRE_SERPAPI_API_KEY", raising=False)
+    with pytest.raises(KeyError, match="SERPAPI_API_KEY not configured"):
+        budget_module.get_api_key("A")
+
+
+def test_get_api_key_account_b_missing_raises_key_error(monkeypatch):
+    monkeypatch.delenv("ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY", raising=False)
+    with pytest.raises(KeyError, match="ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY"):
+        budget_module.get_api_key("B")
+
+
+def test_get_api_key_unknown_account_raises_key_error():
+    with pytest.raises(KeyError, match="Unknown SerpApi account_id"):
+        budget_module.get_api_key("C")
+
+
+def test_mark_account_exhausted_sets_count_to_cap():
+    budget_module.mark_account_exhausted("A", reason="HTTP 429")
+    assert budget_module._get_count_for_account("A") == budget_module.DEFAULT_CAP
+    result = budget_module.select_account()
+    assert result == "B"
+
+
+def test_current_counts_returns_all_accounts():
+    budget_module.try_increment("A")
+    budget_module.try_increment("A")
+    counts = budget_module.current_counts()
+    assert "A" in counts
+    assert "B" in counts
+    assert counts["A"] == 2
+    assert counts["B"] == 0
+
+
+def test_budget_exhausted_error_carries_counts():
+    counts = {"A": 240, "B": 240}
+    exc = budget_module.BudgetExhaustedError(counts)
+    assert exc.counts == counts
+    assert "exhausted" in str(exc).lower()
+    assert "240" in str(exc)
+
+
+def test_try_increment_falls_back_to_in_memory_on_db_error():
+    mock_client = MagicMock()
+    mock_client.rpc.side_effect = Exception("DB unavailable")
+    with patch.object(budget_module, "_init_supabase", return_value=mock_client):
+        budget_module._supabase_init_done = True
+        budget_module._supabase_client = mock_client
+        result = budget_module.try_increment("A")
+    assert result is True
+    month = budget_module._current_month()
+    with budget_module._in_memory_lock:
+        assert budget_module._in_memory_counts.get(month, {}).get("A", 0) == 1

--- a/supabase/migrations/20260512000001_serpapi_budget_and_materials_cache.sql
+++ b/supabase/migrations/20260512000001_serpapi_budget_and_materials_cache.sql
@@ -1,0 +1,83 @@
+-- Migration: serpapi_budget_and_materials_cache
+-- Pass A: SerpApi dual-account budget plumbing + Supabase persistent counter
+-- Applied: 2026-05-12
+
+-- serpapi_budget: persistent dual-account monthly counter
+CREATE TABLE IF NOT EXISTS public.serpapi_budget (
+    month        TEXT    NOT NULL,
+    account_id   TEXT    NOT NULL,
+    count        INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+    cap          INTEGER NOT NULL DEFAULT 240,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (month, account_id)
+);
+CREATE INDEX IF NOT EXISTS idx_serpapi_budget_month ON public.serpapi_budget (month);
+ALTER TABLE public.serpapi_budget ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.serpapi_budget FORCE ROW LEVEL SECURITY;
+CREATE POLICY serpapi_budget_service_all ON public.serpapi_budget
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- materials_search_cache: persistent SerpApi response cache (Pass C will wire write path)
+-- NOTE (Pass C): strip raw thumbnails[]/specifications[] arrays before writing payload
+-- to keep JSONB sizes manageable (these can be 50-200 rows * multi-KB each).
+CREATE TABLE IF NOT EXISTS public.materials_search_cache (
+    cache_key        TEXT        NOT NULL PRIMARY KEY,
+    query_normalized TEXT        NOT NULL,
+    store_id         TEXT        NOT NULL DEFAULT '',
+    engine           TEXT        NOT NULL CHECK (engine IN ('home_depot','shopping','home_depot_product')),
+    payload          JSONB       NOT NULL,
+    fetched_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at       TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_msc_expires_at ON public.materials_search_cache (expires_at);
+CREATE INDEX IF NOT EXISTS idx_msc_engine_store ON public.materials_search_cache (engine, store_id);
+ALTER TABLE public.materials_search_cache ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.materials_search_cache FORCE ROW LEVEL SECURITY;
+CREATE POLICY msc_service_all ON public.materials_search_cache
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- increment_serpapi_budget: atomic increment with cap enforcement
+-- Returns new count, or NULL if account was already at cap (no increment)
+CREATE OR REPLACE FUNCTION public.increment_serpapi_budget(
+    p_month      TEXT,
+    p_account_id TEXT,
+    p_cap        INTEGER DEFAULT 240
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+    v_new_count INTEGER;
+BEGIN
+    INSERT INTO public.serpapi_budget (month, account_id, count, cap)
+    VALUES (p_month, p_account_id, 0, p_cap)
+    ON CONFLICT (month, account_id) DO NOTHING;
+
+    UPDATE public.serpapi_budget
+    SET    count = count + 1, updated_at = now()
+    WHERE  month = p_month AND account_id = p_account_id AND count < p_cap
+    RETURNING count INTO v_new_count;
+
+    RETURN v_new_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.increment_serpapi_budget(TEXT, TEXT, INTEGER) TO service_role;
+
+-- pg_cron monthly reset (graceful degradation if pg_cron not installed)
+DO $$
+BEGIN
+  PERFORM cron.schedule(
+    'serpapi-budget-monthly-reset',
+    '0 0 1 * *',
+    $cron$
+      UPDATE public.serpapi_budget
+      SET    count = 0, updated_at = now()
+      WHERE  month = to_char((now() AT TIME ZONE 'UTC') - interval '1 month', 'YYYY-MM');
+    $cron$
+  );
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'pg_cron not available — manual monthly reset required';
+END $$;


### PR DESCRIPTION
## Summary

Pass A: SerpApi Budget Plumbing for Materials Tab.

- **New `serpapi_budget.py`** — dual-account (A+B) budget manager backed by Supabase `serpapi_budget` table via atomic `increment_serpapi_budget()` RPC. In-memory fallback when DB unavailable. R1 defensive list-unwrap on supabase-py scalar return. `get_api_key()` maps `A→SERPAPI_API_KEY`, `B→ASPIRE_SERPAPI_2ND_ACCOUNT_API_KEY` (exact Railway env var names). `BudgetExhaustedError` with counts payload for receipts.
- **3 adapter patches** — `serpapi_homedepot_client`, `serpapi_shopping_client`, `serpapi_homedepot_product_client` all wired through the dual-account budget gate. On HTTP 429 or quota body signal, marks account exhausted and retries on the other account (single attempt — Law #1: no autonomous retry loops). Receipts augmented with `budget_account_id`, `budget_remaining_a`, `budget_remaining_b`.
- **`cache.py` deprecation** — old single-account `serpapi_increment/serpapi_check_budget/serpapi_get_count/serpapi_budget_error_message` functions stubbed with `DeprecationWarning` delegating to new module.
- **SQL migration** `20260512000001` — `serpapi_budget` table + `materials_search_cache` table (Pass C writes) + `increment_serpapi_budget()` RPC + pg_cron monthly reset.

## Law compliance
- Law #1: adapters never retry autonomously — single 429-failover to other account, then return failure
- Law #2: every code path emits `receipt_data` with budget state
- Law #3: missing env vars → `KeyError` (fail-closed)
- Law #9: API keys never logged — only `account_id` ('A'/'B') appears in logs/receipts

## Test plan
- [ ] 23 new tests pass locally (18 unit + 5 integration)
- [ ] Full regression suite passes (no existing test broken)
- [ ] Supabase migration verified applied: `SELECT * FROM public.serpapi_budget` and `SELECT * FROM public.materials_search_cache` return empty tables
- [ ] Railway auto-deploy triggers on merge
- [ ] Post-deploy probe: `serpapi_budget` rows appear for current month after first real search