### PR TITLE
fix(materials): pass user_address to playbook + robust product extraction

### DIFF
--- a/orchestrator/src/aspire_orchestrator/routes/materials.py
+++ b/orchestrator/src/aspire_orchestrator/routes/materials.py
@@ -234,7 +234,7 @@ async def search_materials(
     keywords, the response includes suggested_mode='supplier'. Client decides
     whether to flip — the server never auto-flips mode.
     """
-    # ── 1. Scope resolution (Law #6) ──────────────────────────────────────────────
+    # ── 1. Scope resolution (Law #6) ────────────────────────────────────
     scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
     suite_id = str(scope.suite_id)
     office_id = str(scope.office_id)
@@ -242,7 +242,7 @@ async def search_materials(
     correlation_id = get_correlation_id() or str(uuid.uuid4())
     trace_id = get_trace_id() or correlation_id
 
-    # ── 2. Capability token validation (Law #5) ──────────────────────────────────────────
+    # ── 2. Capability token validation (Law #5) ───────────────────────────────────
     cap_token_dict: dict[str, Any] | None = None
     if capability_token:
         import json
@@ -286,7 +286,7 @@ async def search_materials(
 
     cap_token_id = _cap_token_id(cap_token_dict)
 
-    # ── 3. Query normalisation + PII rejection ────────────────────────────────────────────
+    # ── 3. Query normalisation + PII rejection ──────────────────────────────────
     normalised = normalize_query(q)
     if isinstance(normalised, NormalizeRejection):
         receipt_id = _emit_receipt(
@@ -307,7 +307,7 @@ async def search_materials(
             },
         )
 
-    # ── 4. Mode validation + supplier-mode dispatch (Pass E) ───────────────────────
+    # ── 4. Mode validation + supplier-mode dispatch (Pass E) ─────────────────
     #
     # Validate mode param (fail-closed: unknown modes are rejected, not silently
     # downgraded to tool mode — that would mask client bugs, Law #3).
@@ -348,7 +348,7 @@ async def search_materials(
             cap_token_id=cap_token_id,
         )
 
-    # ── 5. Idempotency check (tool mode) ─────────────────────────────────────
+    # ── 5. Idempotency check (tool mode) ─────────────────────────────
     if idempotency_key:
         try:
             existing = await supabase_select(
@@ -393,7 +393,7 @@ async def search_materials(
         except SupabaseClientError as exc:
             logger.warning("materials_search idempotency check failed: %s", exc)
 
-    # ── 5a. Resolve address → nearest HD store (tool mode only) ─────────────────
+    # ── 5a. Resolve address → nearest HD store (tool mode only) ─────────────
     # When the client sends the full project address and no explicit store_id,
     # extract the ZIP from the address string and resolve to the nearest HD
     # store via the O(1) static directory. This prevents SerpApi from defaulting
@@ -445,7 +445,7 @@ async def search_materials(
                 # Tool mode will still return results without closest_store.
                 logger.warning("materials_search hd_store address lookup failed: %s", _exc)
 
-    # ── 5. In-memory cache hit ────────────────────────────────────────────────────
+    # ── 5. In-memory cache hit ───────────────────────────────────────
     # Include resolved_store_id/resolved_zip so two addresses that resolve to
     # different HD stores don't share a cache row (Law #6 — tenant isolation
     # within the same suite extends to store-level result isolation).
@@ -493,7 +493,7 @@ async def search_materials(
             "suggested_mode": suggested_mode,
         }
 
-    # ── 6. Budget check — fail gracefully with cached-only mode ────────────
+    # ── 6. Budget check — fail gracefully with cached-only mode ──────────
     account_id = select_account()
     _counts = current_counts()
 
@@ -531,7 +531,7 @@ async def search_materials(
             "suggested_mode": suggested_mode,
         }
 
-    # ── 7. Build PlaybookContext + execute HD search ──────────────────────────────────────
+    # ── 7. Build PlaybookContext + execute HD search ───────────────────────────
     ctx = PlaybookContext(
         suite_id=suite_id,
         office_id=office_id,
@@ -550,6 +550,18 @@ async def search_materials(
                 zip_code=resolved_zip or "",
                 store_id=resolved_store_id or "",
                 voice_path=False,  # R1: text-mode path, 3-attempt loop
+                # Bug fix: pass the raw project address so the playbook can
+                # run its Round-4 Geocode + Places PRIMARY path (Task #43).
+                # When user_address is set, the playbook resolves the actual
+                # nearest HD to the job-site address via Google Places
+                # searchNearby, pins delivery_zip from the resolved store's
+                # postal_code, and skips the city→zip fallback entirely.
+                # Without this, ZIP 30297 (and any ZIP absent from our static
+                # directory) produced products=0 because the static-directory
+                # miss set resolved_store_id=None, leaving the playbook with
+                # only a raw zip_code — which SerpApi accepted but whose
+                # response failed the complete_products completeness gate.
+                user_address=address or "",
             ),
             timeout=_ROUTE_TIMEOUT_SECONDS,
         )
@@ -628,26 +640,91 @@ async def search_materials(
             detail={"error": "PROVIDER_INTERNAL_ERROR", "receipt_id": receipt_id},
         )
 
-    # ── 8. Extract products from research_result ───────────────────────────────────────
+    # ── 8. Extract products from research_result ────────────────────────────
+    # The playbook (execute_tool_material_price_check) packages its results as a
+    # ResearchResponse with:
+    #   records = [store_summary_dict, product_dict, product_dict, ...]
+    #             (card_kind="store_summary" for the first record)
+    #   extra   = {"store_summary": {...}, "taxonomy": [...], ...}
+    #
+    # When the user_address PRIMARY path runs (Round 4), the playbook resolves
+    # the nearest HD via Google Places and stores the resolved store info in
+    # extra["store_summary"]. We prefer that over the static-directory lookup
+    # done earlier in this route.
+    #
+    # Debug logging — grep for "materials_extract" to trace any future failure.
+    _extra = getattr(research_result, "extra", {}) or {}
+    _records = getattr(research_result, "records", None) or []
+    logger.info(
+        "materials_extract playbook result: type=%s records=%d extra_keys=%s",
+        type(research_result).__name__,
+        len(_records),
+        list(_extra.keys()) if isinstance(_extra, dict) else str(type(_extra)),
+    )
+
     products: list[dict[str, Any]] = []
-    records = getattr(research_result, "records", None) or []
-    for rec in records:
-        raw_products = []
-        if hasattr(rec, "products"):
-            raw_products = rec.products or []
-        elif isinstance(rec, dict):
-            raw_products = rec.get("products") or rec.get("results") or []
-        # Normalise records to dicts
-        for p in raw_products:
-            products.append(p if isinstance(p, dict) else (p.__dict__ if hasattr(p, "__dict__") else {}))
+    # Primary extraction path: records is a flat list of dicts.
+    # store_summary records have card_kind="store_summary" — skip them here.
+    for rec in _records:
+        if isinstance(rec, dict):
+            if rec.get("card_kind") in ("store_summary", "store_candidate"):
+                continue  # store cards are not products
+            products.append(rec)
+        elif hasattr(rec, "__dict__"):
+            d = rec.__dict__
+            if d.get("card_kind") in ("store_summary", "store_candidate"):
+                continue
+            products.append(d)
+        # Legacy: rec has a .products attribute (older schema)
+        elif hasattr(rec, "products"):
+            for p in (rec.products or []):
+                products.append(p if isinstance(p, dict) else (p.__dict__ if hasattr(p, "__dict__") else {}))
 
-    # Also check top-level extra dict
-    extra = getattr(research_result, "extra", {}) or {}
-    if not products and extra.get("results"):
-        for item in extra["results"]:
+    logger.info(
+        "materials_extract from records: %d products (skipped store_summary cards)",
+        len(products),
+    )
+
+    # Fallback: top-level extra["results"] (used by legacy path when records is empty)
+    if not products and _extra.get("results"):
+        for item in _extra["results"]:
             products.append(item if isinstance(item, dict) else {})
+        logger.info(
+            "materials_extract from extra.results: %d products",
+            len(products),
+        )
 
-    # ── 9. Specialty fallback (ATTOM POI) when < 3 products ─────────────────────
+    # Bug fix (Bug 3): prefer the playbook's resolved store info over the
+    # static-directory lookup done above. When the Round-4 user_address path
+    # ran successfully, extra["store_summary"] contains Google-verified
+    # store name / address / postal_code for the actual nearest HD to the
+    # job site. We use that in preference to closest_store_info (which was
+    # derived from the static directory and may be null for ZIPs not in the
+    # directory, e.g. 30297 Forest Park GA).
+    _playbook_store: dict[str, Any] | None = None
+    if isinstance(_extra, dict) and isinstance(_extra.get("store_summary"), dict):
+        _ps = _extra["store_summary"]
+        # Only use it if it has a meaningful store name (not a blank/default).
+        if _ps.get("store_name") or _ps.get("name"):
+            _playbook_store = {
+                "id": str(_ps.get("store_id", "")),
+                "name": _ps.get("store_name") or _ps.get("name") or "Home Depot",
+                "address": _ps.get("address", ""),
+                "city": _ps.get("city", ""),
+                "state": _ps.get("state", ""),
+                "zip": str(_ps.get("postal_code", "")).zfill(5) if _ps.get("postal_code") else "",
+            }
+            logger.info(
+                "materials_extract closest_store from playbook store_summary: %s (id=%s zip=%s)",
+                _playbook_store["name"], _playbook_store["id"], _playbook_store["zip"],
+            )
+
+    # Merge: playbook-resolved store wins; static-directory lookup is fallback.
+    closest_store_info = _playbook_store or closest_store_info
+    if closest_store_info is None:
+        logger.info("materials_extract closest_store: none resolved (no address or all lookups failed)")
+
+    # ── 9. Specialty fallback (ATTOM POI) when < 3 products ─────────────────
     specialty_suppliers: list[dict[str, Any]] = []
     if len(products) < 3 and (resolved_zip or zip_code):
         try:
@@ -682,14 +759,14 @@ async def search_materials(
         except Exception as poi_exc:
             logger.warning("materials_search attom_poi fallback failed: %s", poi_exc)
 
-    # ── 10. Derive filters + add-ons ───────────────────────────────────────────────
+    # ── 10. Derive filters + add-ons ───────────────────────────────────
     filters = derive_filters(products)
     addon_suggestions = get_predictive_addons(normalised)
 
-    # ── 11. Sanitize before cache write (Law #9) ────────────────────────────────────
+    # ── 11. Sanitize before cache write (Law #9) ──────────────────────────
     sanitized_products = sanitize_product_list(products)
 
-    # ── 12. Write to in-memory cache (tenant-isolated key, Law #6) ──────────────
+    # ── 12. Write to in-memory cache (tenant-isolated key, Law #6) ──────────
     result_payload: dict[str, Any] = {
         "products": sanitized_products,
         "specialty_suppliers": specialty_suppliers,
@@ -706,7 +783,7 @@ async def search_materials(
         ttl_override=_HD_TTL_SECONDS,
     )
 
-    # ── 13. Persist idempotency record to Supabase ─────────────────────────────────────
+    # ── 13. Persist idempotency record to Supabase ──────────────────────────
     if idempotency_key:
         try:
             await supabase_insert(
@@ -730,7 +807,7 @@ async def search_materials(
         except SupabaseClientError as exc:
             logger.warning("materials_search idempotency persist failed: %s", exc)
 
-    # ── 14. Success receipt ─────────────────────────────────────────────────────────
+    # ── 14. Success receipt ─────────────────────────────────────────
     _counts_final = current_counts()
     receipt_id = _emit_receipt(
         receipt_type="materials_search_success",
@@ -753,8 +830,11 @@ async def search_materials(
     )
 
     logger.info(
-        "materials_search success suite_id=%s query=%s products=%d specialty=%d",
+        "materials_search success suite_id=%s query=%s products=%d specialty=%d "
+        "closest_store=%s closest_store_source=%s",
         suite_id, normalised[:60], len(sanitized_products), len(specialty_suppliers),
+        closest_store_info.get("name") if closest_store_info else "none",
+        "playbook" if _playbook_store else ("static-directory" if closest_store_info else "none"),
     )
 
     return {
@@ -801,7 +881,7 @@ async def _search_suppliers(
 
     location_key = location.strip().lower() if location else ""
 
-    # ── S1. In-memory cache hit ────────────────────────────────────────────────────
+    # ── S1. In-memory cache hit ────────────────────────────────────
     supplier_cache_params = {"location": location_key}
     cached_supplier = cache_get(
         tenant_id=suite_id,
@@ -838,7 +918,7 @@ async def _search_suppliers(
             "mode": "supplier",
         }
 
-    # ── S2. Budget check — fail gracefully (Law #3) ───────────────────────────────
+    # ── S2. Budget check — fail gracefully (Law #3) ───────────────────
     account_id = select_account()
     _counts = current_counts()
 
@@ -870,7 +950,7 @@ async def _search_suppliers(
             "message": "Daily supplier-lookup quota reached",
         }
 
-    # ── S3. Execute Yelp search ───────────────────────────────────────────────────
+    # ── S3. Execute Yelp search ───────────────────────────────────
     try:
         yelp_result = await asyncio.wait_for(
             execute_serpapi_yelp_search(
@@ -932,7 +1012,7 @@ async def _search_suppliers(
             detail={"error": "PROVIDER_INTERNAL_ERROR", "receipt_id": receipt_id},
         )
 
-    # ── S4. Check for budget exhaustion in adapter result ───────────────────────
+    # ── S4. Check for budget exhaustion in adapter result ─────────────────
     if yelp_result.outcome and str(yelp_result.outcome).lower() in ("failed", "error"):
         error_str = yelp_result.error or ""
         is_budget_exhausted = "budget exhausted" in error_str.lower() or "SERPAPI_BUDGET_EXHAUSTED" in error_str
@@ -986,10 +1066,10 @@ async def _search_suppliers(
             detail={"error": "PROVIDER_INTERNAL_ERROR", "receipt_id": receipt_id},
         )
 
-    # ── S5. Extract suppliers ───────────────────────────────────────────────────
+    # ── S5. Extract suppliers ───────────────────────────────────
     suppliers: list[dict[str, Any]] = (yelp_result.data or {}).get("suppliers", [])
 
-    # ── S6. Write to in-memory cache ─────────────────────────────────────────────────
+    # ── S6. Write to in-memory cache ────────────────────────────────
     supplier_payload: dict[str, Any] = {"suppliers": suppliers}
     cache_set(
         tenant_id=suite_id,
@@ -1001,7 +1081,7 @@ async def _search_suppliers(
         ttl_override=_YELP_TTL_SECONDS,
     )
 
-    # ── S7. Persist idempotency record ──────────────────────────────────────────────
+    # ── S7. Persist idempotency record ──────────────────────────────
     if idempotency_key:
         try:
             await supabase_insert(
@@ -1024,7 +1104,7 @@ async def _search_suppliers(
         except SupabaseClientError as exc:
             logger.warning("materials_supplier_search idempotency persist failed: %s", exc)
 
-    # ── S8. Success receipt ────────────────────────────────────────────────────────
+    # ── S8. Success receipt ───────────────────────────────────
     _counts_final = current_counts()
     receipt_id = _emit_receipt(
         receipt_type="materials_supplier_search_success",

--- a/orchestrator/tests/routes/test_materials_search.py
+++ b/orchestrator/tests/routes/test_materials_search.py
@@ -6,6 +6,8 @@ Covers:
                     cross-tenant block, idempotent dedup.
   EVIL-01 to EVIL-04: SQL injection, prompt injection, oversized address, serpapi key not cached.
   ADR-01 to ADR-09: address → HD store resolution wiring (PR fix/materials-address-wiring).
+  FIX-01 to FIX-05: user_address forwarding, product extraction from flat records list,
+                    closest_store from playbook store_summary (fix/materials-tool-extraction).
 """
 from __future__ import annotations
 
@@ -732,3 +734,300 @@ def test_adr09_hd_lookup_exception_fails_soft_returns_200(
     data = resp.json()
     assert data["success"] is True
     assert data.get("closest_store") is None
+
+
+# ---------------------------------------------------------------------------
+# FIX tests — Bug 1: user_address passed to playbook + Bug 2/3: product
+# extraction and closest_store resolution via playbook store_summary
+# (fix/materials-tool-extraction)
+# ---------------------------------------------------------------------------
+
+# Fixture: what execute_tool_material_price_check returns on the user_address
+# PRIMARY path (Round 4) when Google Places resolves a real nearest HD.
+# records = [store_summary_card, product_dict_1, ...] (flat list of dicts,
+# matching the actual playbook output at trades.py:1554).
+_FOREST_PARK_RESOLVED_STORE_SUMMARY = {
+    "card_kind": "store_summary",
+    "store_id": "0559",
+    "store_name": "The Home Depot",
+    "name": "The Home Depot",
+    "address": "5765 Old Dixie Hwy",
+    "city": "Forest Park",
+    "state": "GA",
+    "postal_code": "30297",
+    "phone": "",
+    "website": "",
+    "image_url": "",
+    "open_now": None,
+    "rating": None,
+    "retailer": "Home Depot",
+}
+
+# Products returned by the playbook (already normalized dicts via product.to_dict()).
+_KILZ_PRODUCT = {
+    "product_name": "KILZ 2 ALL PURPOSE 5 gal. Primer",
+    "brand": "KILZ",
+    "model": "L200200",
+    "sku": "100697436",
+    "retailer": "Home Depot",
+    "price": 29.98,
+    "currency": "USD",
+    "availability": "in_stock",
+    "in_store_stock": 12,
+    "store_id": "0559",
+    "store_name": "The Home Depot",
+    "url": "https://www.homedepot.com/p/100697436",
+    "image_url": "https://images.thdstatic.com/productImages/100697436_1000.jpg",
+    "rating": 4.7,
+    "reviews": 1842,
+    "delivery_info": "Free delivery",
+    "sources": [],
+}
+
+_BEHR_PRODUCT = {
+    "product_name": "BEHR PREMIUM PLUS 5 gal. Ultra Pure White",
+    "brand": "BEHR",
+    "model": "105005",
+    "sku": "100689944",
+    "retailer": "Home Depot",
+    "price": 59.98,
+    "currency": "USD",
+    "availability": "in_stock",
+    "in_store_stock": 6,
+    "store_id": "0559",
+    "store_name": "The Home Depot",
+    "url": "https://www.homedepot.com/p/100689944",
+    "image_url": "https://images.thdstatic.com/productImages/100689944_1000.jpg",
+    "rating": 4.5,
+    "reviews": 988,
+    "delivery_info": "Free delivery",
+    "sources": [],
+}
+
+
+def _make_user_address_research_result() -> MagicMock:
+    """Fixture matching the actual ResearchResponse shape from the user_address
+    PRIMARY path.  records is a flat list of dicts (store_summary + products).
+    extra["store_summary"] holds the playbook's resolved store info."""
+    result = MagicMock()
+    result.records = [
+        _FOREST_PARK_RESOLVED_STORE_SUMMARY,
+        _KILZ_PRODUCT,
+        _BEHR_PRODUCT,
+    ]
+    result.extra = {
+        "store_summary": _FOREST_PARK_RESOLVED_STORE_SUMMARY,
+        "cards_version": "v1",
+        "taxonomy": [],
+        "filters": [],
+        "related_products": [],
+        "pagination": {},
+        "nearest_store_distance_miles": 1.4,
+        "hd_too_far": False,
+        "hd_has_stock": True,
+        "include_other_stores": False,
+    }
+    return result
+
+
+@patch("aspire_orchestrator.routes.materials.validate_token")
+@patch("aspire_orchestrator.services.receipt_store.store_receipts")
+@patch("aspire_orchestrator.routes.materials.cache_get", return_value=None)
+@patch("aspire_orchestrator.routes.materials.cache_set")
+@patch("aspire_orchestrator.routes.materials.select_account", return_value="A")
+@patch(
+    "aspire_orchestrator.routes.materials.execute_tool_material_price_check",
+    new_callable=AsyncMock,
+)
+@patch(
+    "aspire_orchestrator.services.adam.hd_store_directory.lookup_store_by_zip_code",
+    return_value=None,  # ZIP 30297 NOT in static directory (the real-world bug condition)
+)
+def test_fix01_user_address_passed_to_playbook(
+    mock_lookup, mock_execute, mock_select, mock_cache_set, mock_cache_get, mock_store, mock_validate
+):
+    """Bug 1: user_address must be forwarded to execute_tool_material_price_check.
+
+    When address=... is supplied and ZIP 30297 is absent from the static directory,
+    the route previously called the playbook WITHOUT user_address, leaving it with
+    only an unresolvable zip and no store_id.  The fix must pass user_address so the
+    playbook can run its Round-4 Google Places PRIMARY path.
+    """
+    mock_validate.return_value = MagicMock(valid=True, error=None)
+    mock_execute.return_value = _make_user_address_research_result()
+
+    resp = _search(
+        "paint",
+        token=_mint_valid_token(),
+        extra_params={"address": "4863 Price St, Forest Park, GA 30297, USA", "mode": "tool"},
+    )
+    assert resp.status_code == 200
+
+    call_kwargs = mock_execute.call_args.kwargs
+    assert call_kwargs.get("user_address") == "4863 Price St, Forest Park, GA 30297, USA", (
+        "user_address must be forwarded to the playbook"
+    )
+
+
+@patch("aspire_orchestrator.routes.materials.validate_token")
+@patch("aspire_orchestrator.services.receipt_store.store_receipts")
+@patch("aspire_orchestrator.routes.materials.cache_get", return_value=None)
+@patch("aspire_orchestrator.routes.materials.cache_set")
+@patch("aspire_orchestrator.routes.materials.select_account", return_value="A")
+@patch(
+    "aspire_orchestrator.routes.materials.execute_tool_material_price_check",
+    new_callable=AsyncMock,
+)
+@patch(
+    "aspire_orchestrator.services.adam.hd_store_directory.lookup_store_by_zip_code",
+    return_value=None,  # ZIP 30297 NOT in static directory
+)
+def test_fix02_products_extracted_from_records_flat_list(
+    mock_lookup, mock_execute, mock_select, mock_cache_set, mock_cache_get, mock_store, mock_validate
+):
+    """Bug 2: products must be extracted from the flat records list.
+
+    The playbook packs results as records=[store_summary, product, product, ...].
+    Store_summary cards (card_kind='store_summary') must be skipped; product dicts
+    must be collected.  For the Forest Park / ZIP 30297 scenario that was returning
+    products=0 in production, this verifies >=1 product is extracted.
+    """
+    mock_validate.return_value = MagicMock(valid=True, error=None)
+    mock_execute.return_value = _make_user_address_research_result()
+
+    resp = _search(
+        "paint",
+        token=_mint_valid_token(),
+        extra_params={"address": "4863 Price St, Forest Park, GA 30297, USA", "mode": "tool"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert len(data["products"]) >= 1, (
+        f"Expected >=1 product but got {len(data['products'])}. "
+        "Check that store_summary cards are skipped and product dicts are collected."
+    )
+    # Verify the KILZ product made it through
+    names = [p.get("product_name", "") for p in data["products"]]
+    assert any("KILZ" in n for n in names), f"KILZ product missing from {names}"
+
+
+@patch("aspire_orchestrator.routes.materials.validate_token")
+@patch("aspire_orchestrator.services.receipt_store.store_receipts")
+@patch("aspire_orchestrator.routes.materials.cache_get", return_value=None)
+@patch("aspire_orchestrator.routes.materials.cache_set")
+@patch("aspire_orchestrator.routes.materials.select_account", return_value="A")
+@patch(
+    "aspire_orchestrator.routes.materials.execute_tool_material_price_check",
+    new_callable=AsyncMock,
+)
+@patch(
+    "aspire_orchestrator.services.adam.hd_store_directory.lookup_store_by_zip_code",
+    return_value=None,  # ZIP 30297 NOT in static directory
+)
+def test_fix03_closest_store_from_playbook_store_summary(
+    mock_lookup, mock_execute, mock_select, mock_cache_set, mock_cache_get, mock_store, mock_validate
+):
+    """Bug 3: closest_store must be populated from the playbook's extra.store_summary
+    when the static directory has no entry for the ZIP (e.g. ZIP 30297, Forest Park GA).
+
+    Previously closest_store was always null in this scenario because it depended
+    exclusively on the static-directory lookup.  The fix prefers the playbook's
+    resolved store info, which is ground-truth (Google Places verified).
+    """
+    mock_validate.return_value = MagicMock(valid=True, error=None)
+    mock_execute.return_value = _make_user_address_research_result()
+
+    resp = _search(
+        "paint",
+        token=_mint_valid_token(),
+        extra_params={"address": "4863 Price St, Forest Park, GA 30297, USA", "mode": "tool"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    cs = data.get("closest_store")
+    assert cs is not None, "closest_store must be populated from playbook store_summary"
+    assert cs["name"] == "The Home Depot", f"wrong name: {cs['name']}"
+    assert cs["id"] == "0559", f"wrong store_id: {cs['id']}"
+    assert cs["zip"] == "30297", f"wrong ZIP: {cs['zip']}"
+
+
+@patch("aspire_orchestrator.routes.materials.validate_token")
+@patch("aspire_orchestrator.services.receipt_store.store_receipts")
+@patch("aspire_orchestrator.routes.materials.cache_get", return_value=None)
+@patch("aspire_orchestrator.routes.materials.cache_set")
+@patch("aspire_orchestrator.routes.materials.select_account", return_value="A")
+@patch(
+    "aspire_orchestrator.routes.materials.execute_tool_material_price_check",
+    new_callable=AsyncMock,
+)
+@patch(
+    "aspire_orchestrator.services.adam.hd_store_directory.lookup_store_by_zip_code",
+    return_value=_FOREST_PARK_STORE,
+)
+def test_fix04_static_directory_closest_store_still_works(
+    mock_lookup, mock_execute, mock_select, mock_cache_set, mock_cache_get, mock_store, mock_validate
+):
+    """Regression: when static directory DOES have the store and the playbook returns
+    no store_summary, closest_store must still come from static directory lookup.
+    This confirms the fallback logic is not broken by the Bug 3 fix.
+    """
+    mock_validate.return_value = MagicMock(valid=True, error=None)
+    # Playbook returns no extra.store_summary (e.g. minimal/error path)
+    result = MagicMock()
+    result.records = [_KILZ_PRODUCT]
+    result.extra = {}
+    mock_execute.return_value = result
+
+    resp = _search(
+        "paint",
+        token=_mint_valid_token(),
+        extra_params={"address": "5765 Old Dixie Hwy, Forest Park, GA 30297", "mode": "tool"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # static-directory closest_store must still appear
+    cs = data.get("closest_store")
+    assert cs is not None, "closest_store must fall back to static-directory when playbook has no store_summary"
+    assert cs["name"] == "The Home Depot"
+
+
+@patch("aspire_orchestrator.routes.materials.validate_token")
+@patch("aspire_orchestrator.services.receipt_store.store_receipts")
+@patch("aspire_orchestrator.routes.materials.cache_get", return_value=None)
+@patch("aspire_orchestrator.routes.materials.cache_set")
+@patch("aspire_orchestrator.routes.materials.select_account", return_value="A")
+@patch(
+    "aspire_orchestrator.routes.materials.execute_tool_material_price_check",
+    new_callable=AsyncMock,
+)
+@patch(
+    "aspire_orchestrator.services.adam.hd_store_directory.lookup_store_by_zip_code",
+    return_value=None,
+)
+def test_fix05_receipt_emitted_on_user_address_path(
+    mock_lookup, mock_execute, mock_select, mock_cache_set, mock_cache_get, mock_store, mock_validate
+):
+    """Law #2: a success receipt must be emitted even when the user_address path runs.
+    Confirms the receipt covers the new code path introduced by the Bug 1 fix.
+    """
+    mock_validate.return_value = MagicMock(valid=True, error=None)
+    mock_execute.return_value = _make_user_address_research_result()
+
+    resp = _search(
+        "paint",
+        token=_mint_valid_token(),
+        extra_params={"address": "4863 Price St, Forest Park, GA 30297, USA", "mode": "tool"},
+    )
+    assert resp.status_code == 200
+    assert mock_store.called, "receipt_store.store_receipts must be called (Law #2)"
+    receipts = mock_store.call_args[0][0]
+    assert len(receipts) >= 1
+    r = receipts[0]
+    assert r["outcome"] == "success"
+    assert r["action_type"] == "materials.search"
+    assert r.get("receipt_id") or r.get("id"), "receipt must have an id"
+    ro = r.get("redacted_outputs", {})
+    assert ro.get("address_provided") is True


### PR DESCRIPTION
## Root cause

Four compounding bugs caused `GET /v1/materials/search?mode=tool&address=4863 Price St, Forest Park, GA 30297` to return `products: 0, closest_store: null` despite SerpApi returning 24 products successfully.

### Bug 1 — Missing `user_address` (primary cause)

`materials.py:547` called `execute_tool_material_price_check` **without** `user_address`. The playbook has a Round-4 PRIMARY path (Task #43): when `user_address` is set, it runs Geocode + Google Places `searchNearby` to pin the nearest HD to the job-site address, sets `delivery_zip` from the resolved store's `postal_code`, and skips the `city→zip` fallback. Without it, the playbook fell through to the fallback path with `zip_code="30297"` and `store_id=""`. SerpApi accepted the bare ZIP but the response products failed the `_product_missing_fields` completeness gate (store info wasn't resolved), so `complete_products` was empty → `final_records = []` → `products=0`.

**Fix:** Pass `user_address=address or ""` to the playbook call.

### Bug 2 — Wrong product extraction logic

The extraction code at `materials.py:632` iterated `research_result.records` looking for a `.products` attribute on each record. The playbook actually emits records as a **flat list of dicts**: `[store_summary_dict, product_dict, product_dict, ...]`. None of those dicts have a `.products` attribute, so every record was silently dropped and `products` stayed `[]`.

**Fix:** Iterate records as flat dicts; skip `card_kind="store_summary"/"store_candidate"` entries; collect product dicts directly. Legacy `extra["results"]` fallback preserved.

### Bug 3 — `closest_store` always null for ZIPs not in static directory

`closest_store_info` was set only by the static directory lookup. ZIP 30297 (Forest Park, GA) is not in the directory, so `closest_store_info = None` regardless of what the playbook resolved. The playbook's `extra["store_summary"]` carries the Google Places-verified store info but was never read by the route.

**Fix:** After playbook returns, prefer `extra["store_summary"]` over `closest_store_info`. Static directory lookup remains the fallback when the playbook has no `store_summary`.

### Bug 4 — No debug visibility

No logging between "playbook returned" and "products extracted", making production failures a guessing game.

**Fix:** Added `materials_extract*` `logger.info` lines at every extraction decision point. Grep `materials_extract` for instant diagnosis.

## Files changed

- `orchestrator/src/aspire_orchestrator/routes/materials.py` — lines 547-564 (Bug 1 call site), lines 643-725 (Bug 2+3+4 extraction block), line 832 (Bug 4 success log)
- `orchestrator/tests/routes/test_materials_search.py` — 5 new FIX tests (FIX-01..05)

## Test results

```
orchestrator/tests/routes/test_materials_search.py  — 34/34 passed (0.65s)
orchestrator/tests/routes/test_materials_bundles.py — 30/30 passed
orchestrator/tests/materials/                       — 39/39 passed
Total: 103 passed, 0 failed
```

## Law compliance

- Law #2: receipt emitted on every code path including new `user_address` branch (FIX-05 verifies)
- Law #3: fail-soft preserved — playbook errors still return 502, not crash; static-directory miss still continues (no regression)
- Law #5/6/9: no changes to token validation, scope enforcement, or PII handling

## Test plan

- [ ] Deploy to Railway (auto-deploys on merge to main)
- [ ] Hit live: `GET /v1/materials/search?q=paint&mode=tool&address=4863+Price+St,+Forest+Park,+GA+30297,+USA` with valid capability token
- [ ] Confirm `products.length > 0` and `closest_store.name` is populated
- [ ] Confirm existing supplier-mode queries still work (no regression)

Generated with [Claude Code](https://claude.ai/claude-code)