### PR TITLE
feat(drew): Wave 1 provider stubs — LlamaParse + Azure Doc Intel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,100 @@
+# Aspire Orchestrator — Environment Variables
+# Copy to .env and fill in values. NEVER commit real secrets.
+# All values are loaded from Railway in production via `railway run`.
+
+# ─── Server ──────────────────────────────────────────────
+ASPIRE_HOST=0.0.0.0
+ASPIRE_PORT=8000
+
+# ─── Supabase ────────────────────────────────────────────
+ASPIRE_SUPABASE_URL=
+ASPIRE_SUPABASE_SERVICE_ROLE_KEY=
+
+# ─── Capability Tokens (Law #5) ───────────────────────────────────────
+ASPIRE_TOKEN_SIGNING_KEY=
+
+# ─── Domain Rail S2S ─────────────────────────────────────────────
+ASPIRE_DOMAIN_RAIL_URL=
+ASPIRE_S2S_HMAC_SECRET=
+
+# ─── OpenAI ───────────────────────────────────────────────────
+ASPIRE_OPENAI_API_KEY=
+
+# ─── Stripe ───────────────────────────────────────────────────
+ASPIRE_STRIPE_API_KEY=
+ASPIRE_STRIPE_WEBHOOK_SECRET=
+
+# ─── Twilio ───────────────────────────────────────────────────
+ASPIRE_TWILIO_ACCOUNT_SID=
+ASPIRE_TWILIO_AUTH_TOKEN=
+ASPIRE_TWILIO_VOICE_API_KEY_SID=
+ASPIRE_TWILIO_VOICE_API_KEY_SECRET=
+ASPIRE_TWILIO_TWIML_APP_SID=
+
+# ─── ElevenLabs ──────────────────────────────────────────────
+ASPIRE_ELEVENLABS_API_KEY=
+ASPIRE_ELEVENLABS_WEBHOOK_SECRET=
+ASPIRE_ELEVENLABS_TOOL_WEBHOOK_SECRET=
+ASPIRE_PERSONALIZATION_WEBHOOK_SECRET=
+
+# ─── Anam ────────────────────────────────────────────────────────
+ASPIRE_ANAM_WEBHOOK_SECRET=
+
+# ─── PandaDoc ────────────────────────────────────────────────
+ASPIRE_PANDADOC_API_KEY=
+ASPIRE_PANDADOC_WEBHOOK_SECRET=
+
+# ─── Deepgram ────────────────────────────────────────────────
+ASPIRE_DEEPGRAM_API_KEY=
+
+# ─── Zoom ────────────────────────────────────────────────────────
+ASPIRE_ZOOM_SDK_KEY=
+ASPIRE_ZOOM_SDK_SECRET=
+ASPIRE_ZOOM_API_KEY=
+ASPIRE_ZOOM_API_SECRET=
+ASPIRE_ZOOM_WEBHOOK_SECRET=
+
+# ─── Adam Research — Geo / Places ───────────────────────────────────────
+ASPIRE_GOOGLE_MAPS_API_KEY=
+ASPIRE_TOMTOM_API_KEY=
+ASPIRE_HERE_API_KEY=
+ASPIRE_FOURSQUARE_API_KEY=
+ASPIRE_MAPBOX_ACCESS_TOKEN=
+
+# ─── Adam Research — Commerce / Data ──────────────────────────────────────
+ASPIRE_ATTOM_API_KEY=
+ASPIRE_EXA_API_KEY=
+ASPIRE_SERPAPI_API_KEY=
+ASPIRE_TRIPADVISOR_API_KEY=
+ASPIRE_PARALLEL_API_KEY=
+ASPIRE_PARALLEL_EXTRACT_API_KEY=
+ASPIRE_APIFY_API_KEY=
+ASPIRE_BRAVE_API_KEY=
+ASPIRE_TAVILY_API_KEY=
+
+# ─── AWS / S3 ──────────────────────────────────────────────────────
+ASPIRE_AWS_ACCESS_KEY_ID=
+ASPIRE_AWS_SECRET_ACCESS_KEY=
+ASPIRE_AWS_S3_REGION=us-east-1
+
+# ─── Google Calendar OAuth2 ────────────────────────────────────────────
+ASPIRE_GOOGLE_CALENDAR_CLIENT_ID=
+ASPIRE_GOOGLE_CALENDAR_CLIENT_SECRET=
+
+# ─── Plaid ───────────────────────────────────────────────────────────
+ASPIRE_PLAID_CLIENT_ID=
+ASPIRE_PLAID_SECRET=
+
+# ─── QuickBooks / Gusto OAuth2 ───────────────────────────────────────────
+ASPIRE_QUICKBOOKS_CLIENT_ID=
+ASPIRE_QUICKBOOKS_CLIENT_SECRET=
+ASPIRE_QUICKBOOKS_BASE_URL=
+ASPIRE_GUSTO_CLIENT_ID=
+ASPIRE_GUSTO_CLIENT_SECRET=
+
+# ─── Drew — Wave 1 (Blueprint Engine) ────────────────────────────────────────────
+ASPIRE_LLAMAPARSE_API_KEY=
+ASPIRE_AZURE_DOC_INTEL_ENDPOINT=
+ASPIRE_AZURE_DOC_INTEL_KEY=
+ASPIRE_DREW_MODEL_DEV=gpt-5.4-mini
+ASPIRE_DREW_MODEL_PROD=gpt-5.2

--- a/orchestrator/src/aspire_orchestrator/config/settings.py
+++ b/orchestrator/src/aspire_orchestrator/config/settings.py
@@ -121,6 +121,13 @@ class Settings(BaseSettings):
     parallel_extract_api_key: str = "" # ASPIRE_PARALLEL_EXTRACT_API_KEY — Parallel Extract (v1beta)
     apify_api_key: str = ""            # ASPIRE_APIFY_API_KEY — Apify Zillow scraper (property photos)
 
+    # --- Drew Blueprint Engine provider keys (Wave 1) ---
+    llamaparse_api_key: str = ""        # ASPIRE_LLAMAPARSE_API_KEY — LlamaParse PDF parser (primary)
+    azure_doc_intel_endpoint: str = ""  # ASPIRE_AZURE_DOC_INTEL_ENDPOINT — Azure Doc Intel endpoint URL
+    azure_doc_intel_key: str = ""       # ASPIRE_AZURE_DOC_INTEL_KEY — Azure subscription key (fallback OCR)
+    drew_model_dev: str = "gpt-5.4-mini"    # ASPIRE_DREW_MODEL_DEV
+    drew_model_prod: str = "gpt-5.2"        # ASPIRE_DREW_MODEL_PROD
+
     # --- Tec Documents (S3) provider keys ---
     aws_access_key_id: str = ""
     aws_secret_access_key: str = ""

--- a/orchestrator/src/aspire_orchestrator/providers/azure_doc_intel_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/azure_doc_intel_client.py
@@ -1,0 +1,189 @@
+"""Azure Document Intelligence Provider Client — OCR fallback for Drew (Blueprint Engine).
+
+Provider: Azure AI Document Intelligence
+         (https://{endpoint}/formrecognizer/documentModels/prebuilt-layout:analyze)
+Auth: API key via Ocp-Apim-Subscription-Key header (ASPIRE_AZURE_DOC_INTEL_KEY)
+Risk tier: GREEN (read-only document analysis)
+Idempotency: N/A (analysis is idempotent — same bytes → same output)
+
+Drew uses Azure Document Intelligence as the FALLBACK OCR layer for scanned
+or image-heavy blueprint sheets where LlamaParse cannot extract structured text.
+
+Wave 1: Stub only — method signature + ProviderRequest shape correct so
+Wave 2 INGEST only needs to flip the NotImplementedError to real wire-up.
+
+Law compliance:
+  #2 — Receipt emission via BaseProviderClient.make_receipt_data()
+  #3 — Fail-closed on missing API key OR endpoint (raises ProviderError before any call)
+  #6 — suite_id/office_id scoped on every ProviderRequest
+  #9 — Never logs pdf_bytes content; logs only len(pdf_bytes) + correlation_id
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aspire_orchestrator.config.settings import settings
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderError,
+    ProviderRequest,
+    ProviderResponse,
+)
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+
+logger = logging.getLogger(__name__)
+
+
+class AzureDocIntelClient(BaseProviderClient):
+    """Azure AI Document Intelligence client for scanned PDF OCR.
+
+    Fallback OCR provider for the Drew Blueprint Engine.
+    The base_url is dynamic (tenant-specific Azure endpoint), so it is resolved
+    from settings at instantiation time rather than as a class attribute.
+
+    All real HTTP execution is in BaseProviderClient._request().
+    This class only supplies auth headers and error mapping.
+    """
+
+    provider_id: str = "azure_doc_intel"
+    # base_url is overridden at __init__ from env (endpoint is tenant-specific)
+    base_url: str = ""
+    timeout_seconds: float = 15.0  # Azure can be slower than LlamaParse — 15s budget
+    max_retries: int = 2
+    idempotency_support: bool = False
+
+    def __init__(self) -> None:
+        """Initialize client and resolve base_url from env. Fail-closed if missing."""
+        super().__init__()
+        endpoint: str = settings.azure_doc_intel_endpoint
+        if not endpoint:
+            raise ProviderError(
+                code=InternalErrorCode.AUTH_INVALID_KEY,
+                message=(
+                    "Azure Document Intelligence endpoint not configured "
+                    "(ASPIRE_AZURE_DOC_INTEL_ENDPOINT)"
+                ),
+                provider_id=self.provider_id,
+            )
+        # Normalise endpoint: strip trailing slash so path joins are clean
+        self.base_url = endpoint.rstrip("/")
+
+    async def _authenticate_headers(
+        self, request: ProviderRequest
+    ) -> dict[str, str]:
+        """Return Azure subscription key header. Fail-closed per Law #3 if key missing."""
+        api_key: str = settings.azure_doc_intel_key
+        if not api_key:
+            raise ProviderError(
+                code=InternalErrorCode.AUTH_INVALID_KEY,
+                message=(
+                    "Azure Document Intelligence API key not configured "
+                    "(ASPIRE_AZURE_DOC_INTEL_KEY)"
+                ),
+                provider_id=self.provider_id,
+            )
+        return {"Ocp-Apim-Subscription-Key": api_key}
+
+    def _parse_error(
+        self, status_code: int, body: dict[str, Any]
+    ) -> InternalErrorCode:
+        """Map Azure Document Intelligence HTTP errors to internal error codes.
+
+        Azure Cognitive Services documented error codes (as of 2025-08):
+          401 — invalid subscription key
+          403 — subscription plan access denied or quota exceeded
+          429 — rate limit exceeded (Retry-After header present)
+          5xx — transient service errors
+        """
+        if status_code == 401:
+            return InternalErrorCode.AUTH_INVALID_KEY
+        if status_code == 403:
+            return InternalErrorCode.DOMAIN_FORBIDDEN
+        if status_code == 429:
+            return InternalErrorCode.RATE_LIMITED
+        if 500 <= status_code < 600:
+            return InternalErrorCode.SERVER_UNAVAILABLE
+        return super()._parse_error(status_code, body)
+
+    async def analyze_layout(
+        self,
+        pdf_bytes: bytes,
+        *,
+        correlation_id: str,
+        suite_id: str,
+        office_id: str,
+    ) -> ProviderResponse:
+        """Analyze a PDF/image document using the Azure prebuilt-layout model.
+
+        PII-safe: only logs byte length, never raw content (Law #9).
+
+        Args:
+            pdf_bytes: Raw PDF or image binary content (never logged).
+            correlation_id: Trace correlation ID (Law #2).
+            suite_id: Tenant suite ID for isolation enforcement (Law #6).
+            office_id: Tenant office ID for isolation enforcement (Law #6).
+
+        Returns:
+            ProviderResponse with layout analysis in body["analyzeResult"] on success.
+            Azure returns an Operation-Location header for async polling — Wave 2
+            must implement the poll loop (GET Operation-Location until status=succeeded).
+
+        Raises:
+            NotImplementedError: Wave 1 stub — Wave 2 INGEST wires real call.
+        """
+        logger.info(
+            "azure_doc_intel.analyze_layout called: suite=%s, corr=%s, size_bytes=%d",
+            suite_id[:8] if len(suite_id) > 8 else suite_id,
+            correlation_id[:8] if len(correlation_id) > 8 else correlation_id,
+            len(pdf_bytes),
+        )
+
+        # Build the ProviderRequest shape so Wave 2 only needs to flip
+        # NotImplementedError → real self._request() + async poll.
+        #
+        # Azure Document Intelligence Layout endpoint:
+        #   POST {endpoint}/formrecognizer/documentModels/prebuilt-layout:analyze
+        #   ?api-version=2023-07-31
+        #
+        # Wave 2 notes:
+        #   - Content-Type must be "application/octet-stream" with raw PDF bytes
+        #   - Response is 202 Accepted + Operation-Location header
+        #   - Poll GET Operation-Location until {"status": "succeeded"}
+        #   - Final result in polled body["analyzeResult"]
+        _request = ProviderRequest(
+            method="POST",
+            path="/formrecognizer/documentModels/prebuilt-layout:analyze",
+            body=None,  # Wave 2: send pdf_bytes as raw octet-stream content
+            query_params={"api-version": "2023-07-31"},
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            extra_headers={
+                "Content-Type": "application/octet-stream",
+                # Wave 2: also needs Accept: application/json (already set by base)
+            },
+        )
+
+        raise NotImplementedError("Wave 2 wires this")
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (matches pattern used by attom_client, brave_client)
+# ---------------------------------------------------------------------------
+
+_client: AzureDocIntelClient | None = None
+
+
+def get_azure_doc_intel_client() -> AzureDocIntelClient:
+    """Return the module-level AzureDocIntelClient singleton.
+
+    Note: instantiation raises ProviderError if ASPIRE_AZURE_DOC_INTEL_ENDPOINT
+    is not set (fail-closed per Law #3). Call from application startup after
+    env vars are loaded.
+    """
+    global _client
+    if _client is None:
+        _client = AzureDocIntelClient()
+    return _client

--- a/orchestrator/src/aspire_orchestrator/providers/llamaparse_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/llamaparse_client.py
@@ -1,0 +1,149 @@
+"""LlamaParse Provider Client — PDF parsing for Drew (Blueprint Engine).
+
+Provider: LlamaIndex Cloud / LlamaParse (https://api.cloud.llamaindex.ai)
+Auth: Bearer token (ASPIRE_LLAMAPARSE_API_KEY)
+Risk tier: GREEN (read-only document parsing)
+Idempotency: N/A (parsing is idempotent by nature — same bytes → same output)
+
+Drew uses LlamaParse as the PRIMARY PDF parser for blueprint/sheet ingestion.
+Azure Document Intelligence is the FALLBACK for scanned/image-heavy sheets.
+
+Wave 1: Stub only — method signature + ProviderRequest shape correct so
+Wave 2 INGEST only needs to flip the NotImplementedError to real wire-up.
+
+Law compliance:
+  #2 — Receipt emission via BaseProviderClient.make_receipt_data()
+  #3 — Fail-closed on missing API key (raises ProviderError before any call)
+  #6 — suite_id/office_id scoped on every ProviderRequest
+  #9 — Never logs pdf_bytes content; logs only len(pdf_bytes) + correlation_id
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aspire_orchestrator.config.settings import settings
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderError,
+    ProviderRequest,
+    ProviderResponse,
+)
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+
+logger = logging.getLogger(__name__)
+
+
+class LlamaParseClient(BaseProviderClient):
+    """LlamaParse API client for PDF → structured text extraction.
+
+    Primary PDF parser for the Drew Blueprint Engine.
+    All real HTTP execution is in BaseProviderClient._request().
+    This class only supplies auth headers and error mapping.
+    """
+
+    provider_id: str = "llamaparse"
+    base_url: str = "https://api.cloud.llamaindex.ai"
+    timeout_seconds: float = 12.0
+    max_retries: int = 1  # Single retry per no-fallback principle (feedback_no_fallback)
+    idempotency_support: bool = False  # LlamaParse has no native idempotency header
+
+    async def _authenticate_headers(
+        self, request: ProviderRequest
+    ) -> dict[str, str]:
+        """Return Bearer auth header. Fail-closed per Law #3 if key missing."""
+        api_key: str = settings.llamaparse_api_key
+        if not api_key:
+            raise ProviderError(
+                code=InternalErrorCode.AUTH_INVALID_KEY,
+                message="LlamaParse API key not configured (ASPIRE_LLAMAPARSE_API_KEY)",
+                provider_id=self.provider_id,
+            )
+        return {"Authorization": f"Bearer {api_key}"}
+
+    def _parse_error(
+        self, status_code: int, body: dict[str, Any]
+    ) -> InternalErrorCode:
+        """Map LlamaParse HTTP errors to internal error codes.
+
+        LlamaParse documented error codes (as of 2025-08):
+          401 — invalid or missing API key
+          429 — rate limit exceeded
+          5xx — provider-side errors
+        """
+        if status_code == 401:
+            return InternalErrorCode.AUTH_INVALID_KEY
+        if status_code == 403:
+            return InternalErrorCode.DOMAIN_FORBIDDEN
+        if status_code == 429:
+            return InternalErrorCode.RATE_LIMITED
+        if 500 <= status_code < 600:
+            return InternalErrorCode.SERVER_UNAVAILABLE
+        return super()._parse_error(status_code, body)
+
+    async def parse_pdf(
+        self,
+        pdf_bytes: bytes,
+        *,
+        correlation_id: str,
+        suite_id: str,
+        office_id: str,
+    ) -> ProviderResponse:
+        """Parse a PDF document into structured text via LlamaParse.
+
+        PII-safe: only logs byte length, never raw content (Law #9).
+
+        Args:
+            pdf_bytes: Raw PDF binary content (never logged).
+            correlation_id: Trace correlation ID (Law #2).
+            suite_id: Tenant suite ID for isolation enforcement (Law #6).
+            office_id: Tenant office ID for isolation enforcement (Law #6).
+
+        Returns:
+            ProviderResponse with parsed markdown/text in body["text"] on success.
+
+        Raises:
+            NotImplementedError: Wave 1 stub — Wave 2 INGEST wires real call.
+        """
+        logger.info(
+            "llamaparse.parse_pdf called: suite=%s, corr=%s, size_bytes=%d",
+            suite_id[:8] if len(suite_id) > 8 else suite_id,
+            correlation_id[:8] if len(correlation_id) > 8 else correlation_id,
+            len(pdf_bytes),
+        )
+
+        # Build the ProviderRequest shape so Wave 2 only needs to flip
+        # NotImplementedError → real self._request() invocation.
+        # LlamaParse upload endpoint: POST /api/parsing/upload (multipart/form-data)
+        # Wave 2 must override _prepare_body() or pass body=None + use httpx streaming
+        # to send the file as multipart. The request shape is documented here.
+        _request = ProviderRequest(
+            method="POST",
+            path="/api/parsing/upload",
+            body=None,  # Wave 2: replace with multipart upload via httpx
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            extra_headers={
+                # Wave 2: add Content-Type: multipart/form-data with boundary
+                # and the actual file bytes as form field "file"
+            },
+        )
+
+        raise NotImplementedError("Wave 2 wires this")
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (matches pattern used by attom_client, brave_client)
+# ---------------------------------------------------------------------------
+
+_client: LlamaParseClient | None = None
+
+
+def get_llamaparse_client() -> LlamaParseClient:
+    """Return the module-level LlamaParseClient singleton."""
+    global _client
+    if _client is None:
+        _client = LlamaParseClient()
+    return _client

--- a/orchestrator/tests/test_drew_providers.py
+++ b/orchestrator/tests/test_drew_providers.py
@@ -1,0 +1,655 @@
+"""Drew Provider Stub Tests — Wave 1.
+
+Validates contract compliance for LlamaParseClient and AzureDocIntelClient:
+  - Fail-closed when env vars missing (Law #3)
+  - Valid ProviderRequest is built before any network call
+  - Stub guard (NotImplementedError) is in place — Wave 2 wires real calls
+  - No network calls made at construction time
+  - Receipt emission path inherited from BaseProviderClient (Law #2)
+  - PII-safe logging: pdf_bytes content never logged, only len()
+
+Cross-reference:
+  - providers/llamaparse_client.py
+  - providers/azure_doc_intel_client.py
+  - providers/base_client.py (BaseProviderClient — receipt emission, circuit breaker)
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from aspire_orchestrator.providers.base_client import ProviderError
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+SUITE_ID = "11111111-1111-4111-8111-111111111111"
+OFFICE_ID = "22222222-2222-4222-8222-222222222222"
+CORRELATION_ID = "test-corr-drew-wave1-001"
+FAKE_PDF_BYTES = b"%PDF-1.4 fake pdf content for testing"
+FAKE_LLAMAPARSE_KEY = "llx-test-key-0000000000000000000000000000000000000000"
+FAKE_AZURE_ENDPOINT = "https://aspire-test.cognitiveservices.azure.com"
+FAKE_AZURE_KEY = "az-test-key-00000000000000000000000000000000"
+
+
+# =============================================================================
+# LlamaParseClient Tests
+# =============================================================================
+
+
+class TestLlamaParseClientMissingCredentials:
+    """Law #3: Fail-closed when ASPIRE_LLAMAPARSE_API_KEY is missing."""
+
+    def test_authenticate_headers_raises_when_key_missing(self) -> None:
+        """_authenticate_headers must raise ProviderError if key is empty."""
+        import asyncio
+
+        mock_settings = MagicMock()
+        mock_settings.llamaparse_api_key = ""  # Empty → fail-closed
+
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            # Build a minimal ProviderRequest to pass to _authenticate_headers
+            from aspire_orchestrator.providers.base_client import ProviderRequest
+
+            req = ProviderRequest(
+                method="POST",
+                path="/api/parsing/upload",
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+            )
+            with pytest.raises(ProviderError) as exc_info:
+                asyncio.get_event_loop().run_until_complete(
+                    client._authenticate_headers(req)
+                )
+
+            assert exc_info.value.code == InternalErrorCode.AUTH_INVALID_KEY
+            assert "ASPIRE_LLAMAPARSE_API_KEY" in exc_info.value.message
+
+    def test_parse_pdf_propagates_auth_error(self) -> None:
+        """parse_pdf must surface ProviderError (AUTH_INVALID_KEY) if key missing.
+
+        Note: parse_pdf raises NotImplementedError as its stub guard, but the
+        auth check in _authenticate_headers fires first when _request is called.
+        For Wave 1, the stub raises NotImplementedError before touching auth,
+        so this test validates the auth path via _authenticate_headers directly.
+        This mirrors the Wave 1 design: method body exits early with NotImplementedError.
+        """
+        # Covered by test_authenticate_headers_raises_when_key_missing above.
+        # Explicit stub guard test is in TestLlamaParseClientStubGuard.
+        pass
+
+
+class TestLlamaParseClientWithValidCredentials:
+    """Verify client construction and ProviderRequest shape with valid credentials."""
+
+    @pytest.fixture
+    def mock_settings_llamaparse(self):
+        mock = MagicMock()
+        mock.llamaparse_api_key = FAKE_LLAMAPARSE_KEY
+        return mock
+
+    def test_construction_makes_no_network_calls(self, mock_settings_llamaparse: MagicMock) -> None:
+        """Constructing LlamaParseClient must not trigger any HTTP calls."""
+        import httpx
+
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            with patch.object(httpx.AsyncClient, "post") as mock_post:
+                from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+                _client = LlamaParseClient()
+                mock_post.assert_not_called()
+
+    def test_provider_id_is_llamaparse(self, mock_settings_llamaparse: MagicMock) -> None:
+        """provider_id must be 'llamaparse' for receipt and circuit breaker keying."""
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            assert client.provider_id == "llamaparse"
+
+    def test_base_url_is_llamaindex_cloud(self, mock_settings_llamaparse: MagicMock) -> None:
+        """base_url must point to LlamaIndex Cloud API."""
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            assert client.base_url == "https://api.cloud.llamaindex.ai"
+
+    def test_timeout_is_12_seconds(self, mock_settings_llamaparse: MagicMock) -> None:
+        """timeout_seconds must be 12.0 — Drew blueprint parsing budget."""
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            assert client.timeout_seconds == 12.0
+
+    def test_max_retries_is_1(self, mock_settings_llamaparse: MagicMock) -> None:
+        """max_retries must be 1 — single retry per no-fallback principle."""
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            assert client.max_retries == 1
+
+    def test_authenticate_headers_returns_bearer(self, mock_settings_llamaparse: MagicMock) -> None:
+        """_authenticate_headers must return correct Bearer token header."""
+        import asyncio
+
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+            from aspire_orchestrator.providers.base_client import ProviderRequest
+
+            client = LlamaParseClient()
+            req = ProviderRequest(
+                method="POST",
+                path="/api/parsing/upload",
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+            )
+            headers = asyncio.get_event_loop().run_until_complete(
+                client._authenticate_headers(req)
+            )
+
+        assert headers == {"Authorization": f"Bearer {FAKE_LLAMAPARSE_KEY}"}
+
+
+class TestLlamaParseClientStubGuard:
+    """Wave 1 stub guard: parse_pdf must raise NotImplementedError."""
+
+    @pytest.fixture
+    def mock_settings_llamaparse(self):
+        mock = MagicMock()
+        mock.llamaparse_api_key = FAKE_LLAMAPARSE_KEY
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_parse_pdf_raises_not_implemented(
+        self, mock_settings_llamaparse: MagicMock
+    ) -> None:
+        """parse_pdf must raise NotImplementedError until Wave 2 wires it."""
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+
+            with pytest.raises(NotImplementedError, match="Wave 2 wires this"):
+                await client.parse_pdf(
+                    FAKE_PDF_BYTES,
+                    correlation_id=CORRELATION_ID,
+                    suite_id=SUITE_ID,
+                    office_id=OFFICE_ID,
+                )
+
+    @pytest.mark.asyncio
+    async def test_parse_pdf_logs_byte_length_not_content(
+        self, mock_settings_llamaparse: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Law #9: parse_pdf logs len(pdf_bytes), never raw content.
+
+        We verify that the raw PDF sentinel string does not appear in log output
+        but the byte count does.
+        """
+        import logging
+
+        PDF_SENTINEL = b"SENSITIVE_BLUEPRINT_CONTENT_DO_NOT_LOG"
+
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings_llamaparse,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+
+            with caplog.at_level(logging.INFO, logger="aspire_orchestrator.providers.llamaparse_client"):
+                with pytest.raises(NotImplementedError):
+                    await client.parse_pdf(
+                        PDF_SENTINEL,
+                        correlation_id=CORRELATION_ID,
+                        suite_id=SUITE_ID,
+                        office_id=OFFICE_ID,
+                    )
+
+        full_log = " ".join(caplog.messages)
+        # PII-safe: raw content must not appear in any log line
+        assert "SENSITIVE_BLUEPRINT_CONTENT_DO_NOT_LOG" not in full_log
+        # Byte length must appear (proves the safe logging path fired)
+        assert str(len(PDF_SENTINEL)) in full_log
+
+
+class TestLlamaParseClientErrorMapping:
+    """Verify _parse_error maps provider HTTP codes to canonical InternalErrorCode."""
+
+    @pytest.fixture
+    def client(self):
+        mock_settings = MagicMock()
+        mock_settings.llamaparse_api_key = FAKE_LLAMAPARSE_KEY
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+            return LlamaParseClient()
+
+    def test_401_maps_to_auth_invalid_key(self, client: "LlamaParseClient") -> None:
+        assert client._parse_error(401, {}) == InternalErrorCode.AUTH_INVALID_KEY
+
+    def test_403_maps_to_domain_forbidden(self, client: "LlamaParseClient") -> None:
+        assert client._parse_error(403, {}) == InternalErrorCode.DOMAIN_FORBIDDEN
+
+    def test_429_maps_to_rate_limited(self, client: "LlamaParseClient") -> None:
+        assert client._parse_error(429, {}) == InternalErrorCode.RATE_LIMITED
+
+    def test_500_maps_to_server_unavailable(self, client: "LlamaParseClient") -> None:
+        assert client._parse_error(500, {}) == InternalErrorCode.SERVER_UNAVAILABLE
+
+    def test_503_maps_to_server_unavailable(self, client: "LlamaParseClient") -> None:
+        assert client._parse_error(503, {}) == InternalErrorCode.SERVER_UNAVAILABLE
+
+    def test_400_falls_through_to_base(self, client: "LlamaParseClient") -> None:
+        """400 uses base class mapping → INPUT_INVALID_FORMAT."""
+        assert client._parse_error(400, {}) == InternalErrorCode.INPUT_INVALID_FORMAT
+
+
+class TestLlamaParseReceiptEmission:
+    """Law #2: Verify receipt emission is inherited from BaseProviderClient."""
+
+    def test_make_receipt_data_is_callable(self) -> None:
+        """LlamaParseClient inherits make_receipt_data from BaseProviderClient."""
+        from aspire_orchestrator.providers.base_client import BaseProviderClient
+        from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+        assert hasattr(LlamaParseClient, "make_receipt_data")
+        # Confirmed via inheritance — not overridden
+        assert LlamaParseClient.make_receipt_data is BaseProviderClient.make_receipt_data
+
+    def test_make_receipt_data_produces_required_fields(self) -> None:
+        """make_receipt_data must produce all Law #2 required fields."""
+        from unittest.mock import MagicMock, patch
+        from aspire_orchestrator.models import Outcome
+
+        mock_settings = MagicMock()
+        mock_settings.llamaparse_api_key = FAKE_LLAMAPARSE_KEY
+
+        with patch(
+            "aspire_orchestrator.providers.llamaparse_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.llamaparse_client import LlamaParseClient
+
+            client = LlamaParseClient()
+            receipt = client.make_receipt_data(
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+                tool_id="llamaparse.parse_pdf",
+                risk_tier="green",
+                outcome=Outcome.SUCCESS,
+                reason_code="PARSED",
+            )
+
+        required_fields = {
+            "id", "correlation_id", "suite_id", "office_id",
+            "actor_type", "actor_id", "action_type", "risk_tier",
+            "tool_used", "created_at", "executed_at", "outcome", "reason_code",
+        }
+        for field in required_fields:
+            assert field in receipt, f"Receipt missing required field: {field}"
+
+        assert receipt["suite_id"] == SUITE_ID
+        assert receipt["office_id"] == OFFICE_ID
+        assert receipt["correlation_id"] == CORRELATION_ID
+
+
+# =============================================================================
+# AzureDocIntelClient Tests
+# =============================================================================
+
+
+class TestAzureDocIntelClientMissingEndpoint:
+    """Law #3: Fail-closed when ASPIRE_AZURE_DOC_INTEL_ENDPOINT is missing."""
+
+    def test_construction_raises_when_endpoint_missing(self) -> None:
+        """AzureDocIntelClient.__init__ must raise ProviderError if endpoint empty."""
+        mock_settings = MagicMock()
+        mock_settings.azure_doc_intel_endpoint = ""  # Missing → fail-closed
+        mock_settings.azure_doc_intel_key = FAKE_AZURE_KEY
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            with pytest.raises(ProviderError) as exc_info:
+                AzureDocIntelClient()
+
+            assert exc_info.value.code == InternalErrorCode.AUTH_INVALID_KEY
+            assert "ASPIRE_AZURE_DOC_INTEL_ENDPOINT" in exc_info.value.message
+
+
+class TestAzureDocIntelClientMissingKey:
+    """Law #3: Fail-closed when ASPIRE_AZURE_DOC_INTEL_KEY is missing."""
+
+    def test_authenticate_headers_raises_when_key_missing(self) -> None:
+        """_authenticate_headers must raise ProviderError if API key is empty."""
+        import asyncio
+
+        mock_settings = MagicMock()
+        mock_settings.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT
+        mock_settings.azure_doc_intel_key = ""  # Missing → fail-closed
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+            from aspire_orchestrator.providers.base_client import ProviderRequest
+
+            client = AzureDocIntelClient()
+            req = ProviderRequest(
+                method="POST",
+                path="/formrecognizer/documentModels/prebuilt-layout:analyze",
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+            )
+
+            with pytest.raises(ProviderError) as exc_info:
+                asyncio.get_event_loop().run_until_complete(
+                    client._authenticate_headers(req)
+                )
+
+            assert exc_info.value.code == InternalErrorCode.AUTH_INVALID_KEY
+            assert "ASPIRE_AZURE_DOC_INTEL_KEY" in exc_info.value.message
+
+
+class TestAzureDocIntelClientWithValidCredentials:
+    """Verify client construction and ProviderRequest shape with valid credentials."""
+
+    @pytest.fixture
+    def mock_settings_azure(self):
+        mock = MagicMock()
+        mock.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT
+        mock.azure_doc_intel_key = FAKE_AZURE_KEY
+        return mock
+
+    def test_construction_makes_no_network_calls(self, mock_settings_azure: MagicMock) -> None:
+        """Constructing AzureDocIntelClient must not trigger any HTTP calls."""
+        import httpx
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            with patch.object(httpx.AsyncClient, "post") as mock_post:
+                from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+                _client = AzureDocIntelClient()
+                mock_post.assert_not_called()
+
+    def test_provider_id_is_azure_doc_intel(self, mock_settings_azure: MagicMock) -> None:
+        """provider_id must be 'azure_doc_intel'."""
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            assert client.provider_id == "azure_doc_intel"
+
+    def test_base_url_set_from_endpoint_env(self, mock_settings_azure: MagicMock) -> None:
+        """base_url must be set from ASPIRE_AZURE_DOC_INTEL_ENDPOINT with trailing slash stripped."""
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            assert client.base_url == FAKE_AZURE_ENDPOINT.rstrip("/")
+
+    def test_trailing_slash_stripped_from_endpoint(self, mock_settings_azure: MagicMock) -> None:
+        """base_url must strip trailing slash from endpoint to avoid double-slash paths."""
+        mock_settings_azure.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT + "/"
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            assert not client.base_url.endswith("/")
+
+    def test_timeout_is_15_seconds(self, mock_settings_azure: MagicMock) -> None:
+        """timeout_seconds must be 15.0 — Azure can be slower than LlamaParse."""
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            assert client.timeout_seconds == 15.0
+
+    def test_max_retries_is_2(self, mock_settings_azure: MagicMock) -> None:
+        """max_retries must be 2."""
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            assert client.max_retries == 2
+
+    def test_authenticate_headers_returns_subscription_key(
+        self, mock_settings_azure: MagicMock
+    ) -> None:
+        """_authenticate_headers must return Ocp-Apim-Subscription-Key header."""
+        import asyncio
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+            from aspire_orchestrator.providers.base_client import ProviderRequest
+
+            client = AzureDocIntelClient()
+            req = ProviderRequest(
+                method="POST",
+                path="/formrecognizer/documentModels/prebuilt-layout:analyze",
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+            )
+            headers = asyncio.get_event_loop().run_until_complete(
+                client._authenticate_headers(req)
+            )
+
+        assert headers == {"Ocp-Apim-Subscription-Key": FAKE_AZURE_KEY}
+
+
+class TestAzureDocIntelClientStubGuard:
+    """Wave 1 stub guard: analyze_layout must raise NotImplementedError."""
+
+    @pytest.fixture
+    def mock_settings_azure(self):
+        mock = MagicMock()
+        mock.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT
+        mock.azure_doc_intel_key = FAKE_AZURE_KEY
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_analyze_layout_raises_not_implemented(
+        self, mock_settings_azure: MagicMock
+    ) -> None:
+        """analyze_layout must raise NotImplementedError until Wave 2 wires it."""
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+
+            with pytest.raises(NotImplementedError, match="Wave 2 wires this"):
+                await client.analyze_layout(
+                    FAKE_PDF_BYTES,
+                    correlation_id=CORRELATION_ID,
+                    suite_id=SUITE_ID,
+                    office_id=OFFICE_ID,
+                )
+
+    @pytest.mark.asyncio
+    async def test_analyze_layout_logs_byte_length_not_content(
+        self, mock_settings_azure: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Law #9: analyze_layout logs len(pdf_bytes), never raw content."""
+        import logging
+
+        PDF_SENTINEL = b"SENSITIVE_BLUEPRINT_CONTENT_DO_NOT_LOG"
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings_azure,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+
+            with caplog.at_level(
+                logging.INFO,
+                logger="aspire_orchestrator.providers.azure_doc_intel_client",
+            ):
+                with pytest.raises(NotImplementedError):
+                    await client.analyze_layout(
+                        PDF_SENTINEL,
+                        correlation_id=CORRELATION_ID,
+                        suite_id=SUITE_ID,
+                        office_id=OFFICE_ID,
+                    )
+
+        full_log = " ".join(caplog.messages)
+        assert "SENSITIVE_BLUEPRINT_CONTENT_DO_NOT_LOG" not in full_log
+        assert str(len(PDF_SENTINEL)) in full_log
+
+
+class TestAzureDocIntelClientErrorMapping:
+    """Verify _parse_error maps provider HTTP codes to canonical InternalErrorCode."""
+
+    @pytest.fixture
+    def client(self):
+        mock_settings = MagicMock()
+        mock_settings.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT
+        mock_settings.azure_doc_intel_key = FAKE_AZURE_KEY
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+            return AzureDocIntelClient()
+
+    def test_401_maps_to_auth_invalid_key(self, client: "AzureDocIntelClient") -> None:
+        assert client._parse_error(401, {}) == InternalErrorCode.AUTH_INVALID_KEY
+
+    def test_403_maps_to_domain_forbidden(self, client: "AzureDocIntelClient") -> None:
+        assert client._parse_error(403, {}) == InternalErrorCode.DOMAIN_FORBIDDEN
+
+    def test_429_maps_to_rate_limited(self, client: "AzureDocIntelClient") -> None:
+        assert client._parse_error(429, {}) == InternalErrorCode.RATE_LIMITED
+
+    def test_500_maps_to_server_unavailable(self, client: "AzureDocIntelClient") -> None:
+        assert client._parse_error(500, {}) == InternalErrorCode.SERVER_UNAVAILABLE
+
+    def test_503_maps_to_server_unavailable(self, client: "AzureDocIntelClient") -> None:
+        assert client._parse_error(503, {}) == InternalErrorCode.SERVER_UNAVAILABLE
+
+    def test_400_falls_through_to_base(self, client: "AzureDocIntelClient") -> None:
+        """400 uses base class mapping → INPUT_INVALID_FORMAT."""
+        assert client._parse_error(400, {}) == InternalErrorCode.INPUT_INVALID_FORMAT
+
+
+class TestAzureDocIntelReceiptEmission:
+    """Law #2: Verify receipt emission is inherited from BaseProviderClient."""
+
+    def test_make_receipt_data_is_callable(self) -> None:
+        """AzureDocIntelClient inherits make_receipt_data from BaseProviderClient."""
+        from aspire_orchestrator.providers.base_client import BaseProviderClient
+        from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+        assert hasattr(AzureDocIntelClient, "make_receipt_data")
+        assert AzureDocIntelClient.make_receipt_data is BaseProviderClient.make_receipt_data
+
+    def test_make_receipt_data_produces_required_fields(self) -> None:
+        """make_receipt_data must produce all Law #2 required fields."""
+        from aspire_orchestrator.models import Outcome
+
+        mock_settings = MagicMock()
+        mock_settings.azure_doc_intel_endpoint = FAKE_AZURE_ENDPOINT
+        mock_settings.azure_doc_intel_key = FAKE_AZURE_KEY
+
+        with patch(
+            "aspire_orchestrator.providers.azure_doc_intel_client.settings",
+            mock_settings,
+        ):
+            from aspire_orchestrator.providers.azure_doc_intel_client import AzureDocIntelClient
+
+            client = AzureDocIntelClient()
+            receipt = client.make_receipt_data(
+                correlation_id=CORRELATION_ID,
+                suite_id=SUITE_ID,
+                office_id=OFFICE_ID,
+                tool_id="azure_doc_intel.analyze_layout",
+                risk_tier="green",
+                outcome=Outcome.SUCCESS,
+                reason_code="ANALYZED",
+            )
+
+        required_fields = {
+            "id", "correlation_id", "suite_id", "office_id",
+            "actor_type", "actor_id", "action_type", "risk_tier",
+            "tool_used", "created_at", "executed_at", "outcome", "reason_code",
+        }
+        for field in required_fields:
+            assert field in receipt, f"Receipt missing required field: {field}"
+
+        assert receipt["suite_id"] == SUITE_ID
+        assert receipt["office_id"] == OFFICE_ID
+        assert receipt["correlation_id"] == CORRELATION_ID


### PR DESCRIPTION
## Objective

Stand up two new external-API provider clients that Drew (Blueprint Engine) will use for blueprint PDF parsing. Both are Wave 1 stubs — correct auth, error mapping, and `ProviderRequest` shapes are fully wired; actual HTTP calls raise `NotImplementedError("Wave 2 wires this")` so Wave 2 INGEST only needs to flip that guard to the real call.

Parallel work: `aspire-architect` is on `feat/wave-1-drew-skeleton` building Drew's skill pack, migration 100, schemas, and policy pack. This PR does not touch those files.

## Facts

Verified by reading before writing:
- `base_client.py` — `BaseProviderClient` provides circuit breaker, exponential backoff, timeout enforcement, receipt emission (`make_receipt_data`), and PII-safe logging. Subclasses implement `_authenticate_headers` + `_parse_error` only.
- `attom_client.py` / `brave_client.py` — canonical subclass pattern: `provider_id`, `base_url`, `timeout_seconds`, `max_retries`, `_authenticate_headers` raises `ProviderError(AUTH_INVALID_KEY)` when key empty.
- `error_codes.py` — `InternalErrorCode` enum with `.retryable` and `.circuit_breaker_relevant` properties already covers all required mappings.
- `config/settings.py` — Pydantic `BaseSettings` with `env_prefix = "ASPIRE_"`. Added 5 new fields; no existing fields touched.
- `ProviderConfigError` does not exist in codebase — correct pattern is `ProviderError(code=AUTH_INVALID_KEY)`.

## Decision

Mirror the `brave_client.py` / `attom_client.py` shape exactly. Azure endpoint is dynamic (tenant-scoped), so `base_url` is resolved at `__init__` time and the constructor raises `ProviderError` if missing — this is the only client in the providers directory that does this, and it is the correct fail-closed approach.

## Changes

| File | Action | Description |
|------|--------|-------------|
| `orchestrator/src/aspire_orchestrator/providers/llamaparse_client.py` | NEW | `LlamaParseClient` — Bearer auth, 12s timeout, 1 retry, `parse_pdf` stub |
| `orchestrator/src/aspire_orchestrator/providers/azure_doc_intel_client.py` | NEW | `AzureDocIntelClient` — `Ocp-Apim-Subscription-Key` auth, 15s timeout, 2 retries, endpoint resolved at init, `analyze_layout` stub |
| `orchestrator/src/aspire_orchestrator/config/settings.py` | MODIFIED | 5 new fields: `llamaparse_api_key`, `azure_doc_intel_endpoint`, `azure_doc_intel_key`, `drew_model_dev`, `drew_model_prod` |
| `orchestrator/tests/test_drew_providers.py` | NEW | 37 tests covering fail-closed, construction, auth headers, stub guards, PII-safe logging, error mapping, receipt inheritance |
| `.env.example` | NEW | All orchestrator env vars documented (did not previously exist); Drew Wave 1 section at bottom |

### Key design choices for Wave 2 handoff

**LlamaParse** (`parse_pdf`):
- Endpoint: `POST /api/parsing/upload` (multipart/form-data)
- Wave 2: override `_prepare_body()` or use httpx streaming for multipart; current `body=None` is intentional

**Azure Doc Intel** (`analyze_layout`):
- Endpoint: `POST {endpoint}/formrecognizer/documentModels/prebuilt-layout:analyze?api-version=2023-07-31`
- Response: 202 + `Operation-Location` header → async poll until `{"status": "succeeded"}`
- Wave 2 must implement the poll loop; documented in method docstring

## Verification

```
pytest orchestrator/tests/test_drew_providers.py -v --no-header

tests/test_drew_providers.py::TestLlamaParseClientMissingCredentials::test_authenticate_headers_raises_when_key_missing PASSED
tests/test_drew_providers.py::TestLlamaParseClientMissingCredentials::test_parse_pdf_propagates_auth_error PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_construction_makes_no_network_calls PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_provider_id_is_llamaparse PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_base_url_is_llamaindex_cloud PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_timeout_is_12_seconds PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_max_retries_is_1 PASSED
tests/test_drew_providers.py::TestLlamaParseClientWithValidCredentials::test_authenticate_headers_returns_bearer PASSED
tests/test_drew_providers.py::TestLlamaParseClientStubGuard::test_parse_pdf_raises_not_implemented PASSED
tests/test_drew_providers.py::TestLlamaParseClientStubGuard::test_parse_pdf_logs_byte_length_not_content PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_401_maps_to_auth_invalid_key PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_403_maps_to_domain_forbidden PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_429_maps_to_rate_limited PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_500_maps_to_server_unavailable PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_503_maps_to_server_unavailable PASSED
tests/test_drew_providers.py::TestLlamaParseClientErrorMapping::test_400_falls_through_to_base PASSED
tests/test_drew_providers.py::TestLlamaParseReceiptEmission::test_make_receipt_data_is_callable PASSED
tests/test_drew_providers.py::TestLlamaParseReceiptEmission::test_make_receipt_data_produces_required_fields PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientMissingEndpoint::test_construction_raises_when_endpoint_missing PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientMissingKey::test_authenticate_headers_raises_when_key_missing PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_construction_makes_no_network_calls PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_provider_id_is_azure_doc_intel PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_base_url_set_from_endpoint_env PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_trailing_slash_stripped_from_endpoint PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_timeout_is_15_seconds PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_max_retries_is_2 PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientWithValidCredentials::test_authenticate_headers_returns_subscription_key PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientStubGuard::test_analyze_layout_raises_not_implemented PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientStubGuard::test_analyze_layout_logs_byte_length_not_content PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_401_maps_to_auth_invalid_key PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_403_maps_to_domain_forbidden PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_429_maps_to_rate_limited PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_500_maps_to_server_unavailable PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_503_maps_to_server_unavailable PASSED
tests/test_drew_providers.py::TestAzureDocIntelClientErrorMapping::test_400_falls_through_to_base PASSED
tests/test_drew_providers.py::TestAzureDocIntelReceiptEmission::test_make_receipt_data_is_callable PASSED
tests/test_drew_providers.py::TestAzureDocIntelReceiptEmission::test_make_receipt_data_produces_required_fields PASSED

======================== 37 passed, 1 warning in 0.36s ========================
```

## Risks & Next Steps

- **Wave 2 INGEST** must flip `NotImplementedError` to real HTTP calls. LlamaParse requires multipart upload; Azure requires octet-stream POST + async 202 poll. Both shapes are documented in the method docstrings.
- **Railway secrets**: Add `ASPIRE_LLAMAPARSE_API_KEY`, `ASPIRE_AZURE_DOC_INTEL_ENDPOINT`, `ASPIRE_AZURE_DOC_INTEL_KEY` before Wave 2 deploys. No secrets in this PR.
- **LlamaParse base_url**: Using `https://api.cloud.llamaindex.ai` (from spec). Context7 does not have LlamaParse-specific docs; this is the current production endpoint per their public documentation. Wave 2 should verify against live API response headers.
- **Azure async poll**: The 202 pattern means `_request()` alone is insufficient for Azure — Wave 2 must add a poll loop outside `_request()`. The stub's `ProviderRequest` shape documents the initial POST; polling is a separate concern.