### PR TITLE
feat(drew): Wave 1A — Blueprint Story Engine skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,9 @@ tmp_*.json
 scripts/__pycache__/
 plan/temp_ecosystem_scan/
 
+# Drew blueprint fixtures — originals contain PII pre-redaction; only redacted versions commit
+orchestrator/tests/fixtures/blueprints/originals/*
+!orchestrator/tests/fixtures/blueprints/originals/.gitkeep
+
 # Misc
 *.log

--- a/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/freshness_policy.yaml
+++ b/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/freshness_policy.yaml
@@ -1,0 +1,11 @@
+# Drew Blueprint — Freshness Policy
+# Sheet revisions older than this are flagged as stale (Addenda check).
+
+pack_id: drew-blueprint
+
+max_sheet_revision_age_days: 30
+
+cache:
+  enabled: true
+  parsed_sheet_ttl_seconds: 86400
+  symbol_detection_ttl_seconds: 86400

--- a/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/risk_policy.yaml
+++ b/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/risk_policy.yaml
@@ -1,0 +1,36 @@
+# Drew Blueprint — Risk Policy
+# Confidence floors that gate auto-pricing and auto-bid emission.
+
+pack_id: drew-blueprint
+default_risk_tier: green
+max_risk_tier: yellow
+
+auto_pricing_confidence_floor: 0.85
+auto_bid_min_line_item_confidence: 0.85
+auto_bid_min_coverage_pct: 80
+
+actions:
+  blueprint.ingest:
+    risk_tier: green
+    approval_required: false
+    description: "Parse PDFs / images into sheet rows"
+
+  blueprint.classify:
+    risk_tier: green
+    approval_required: false
+    description: "Discipline + revision tagging"
+
+  blueprint.see:
+    risk_tier: green
+    approval_required: false
+    description: "Symbol + bbox detection via vision"
+
+  blueprint.reason:
+    risk_tier: green
+    approval_required: false
+    description: "Assemblies + story-by-phase reasoning"
+
+  blueprint.procure:
+    risk_tier: yellow
+    approval_required: true
+    description: "Push material requests to supplier playbooks"

--- a/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/sources_policy.yaml
+++ b/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/sources_policy.yaml
@@ -1,0 +1,12 @@
+# Drew Blueprint — Sources Policy
+# Provider preference order for PDF parsing.
+
+pack_id: drew-blueprint
+
+parsing:
+  primary: llamaparse
+  fallback: azure_doc_intel
+
+source_requirements:
+  require_sheet_hash: true
+  require_revision_tag: true

--- a/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/tool_policy.yaml
+++ b/orchestrator/src/aspire_orchestrator/config/pack_policies/drew/tool_policy.yaml
@@ -1,0 +1,21 @@
+# Drew Blueprint — Tool Policy
+# Which symbol classes Drew is allowed to auto-extract vs. those that require human review.
+
+pack_id: drew-blueprint
+
+authorized_tools:
+  - blueprint.parse
+  - blueprint.classify
+  - blueprint.detect_symbols
+  - blueprint.reason
+  - blueprint.procure
+
+auto_extract_symbol_classes:
+  - door
+  - window
+  - plumbing_fixture
+  - electrical_outlet
+
+human_review_required_classes:
+  - structural_column
+  - panel_schedule

--- a/orchestrator/src/aspire_orchestrator/nodes/agent_dispatch.py
+++ b/orchestrator/src/aspire_orchestrator/nodes/agent_dispatch.py
@@ -59,6 +59,7 @@ def _init_registry() -> dict[str, Any]:
         "mail_ops": ("aspire_orchestrator.skillpacks.mail_ops_desk", "EnhancedMailOps"),
         "ava": ("aspire_orchestrator.skillpacks.ava_user", "EnhancedAvaUser"),
         "ava_admin": ("aspire_orchestrator.skillpacks.ava_admin", "AvaAdminSkillPack"),
+        "drew": ("aspire_orchestrator.skillpacks.drew_blueprint", "Drew"),
     }
 
     for agent_id, (module_path, class_name) in _class_map.items():

--- a/orchestrator/src/aspire_orchestrator/server.py
+++ b/orchestrator/src/aspire_orchestrator/server.py
@@ -1562,7 +1562,7 @@ async def a2a_dispatch(request: Request) -> JSONResponse:
 # =============================================================================
 
 
-SYNC_INVOKE_AGENTS = {"quinn", "adam", "tec"}
+SYNC_INVOKE_AGENTS = {"quinn", "adam", "tec", "drew"}
 
 
 @app.post("/v1/agents/invoke")
@@ -1695,6 +1695,22 @@ async def agents_invoke_sync(request: Request) -> JSONResponse:
                 full_task = detail_text
             else:
                 full_task = f"{task}. {detail_text}"
+
+        # ── Drew: Blueprint Story Engine (Wave 1A skeleton) ──
+        # 5-stage pipeline (INGEST/CLASSIFY/SEE/REASON/PROCURE).
+        # V1 sync only, mirrors Adam pattern. Currently returns stub responses.
+        if agent == "drew":
+            from aspire_orchestrator.skillpacks.drew_blueprint import Drew as DrewSkillPack
+            drew = DrewSkillPack()
+            payload = body.get("payload", {}) or {}
+            if not isinstance(payload, dict):
+                payload = {}
+            result = drew.run_agentic_loop(
+                task=task,
+                payload=payload,
+                correlation_id=ctx.correlation_id,
+            )
+            return JSONResponse(result)
 
         # ── Adam: Research via Ultra Router (19 playbooks, 13 providers) ──
         # Routes through classify_fast → route_to_playbook → dispatch_playbook.

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-aspire-laws.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-aspire-laws.md
@@ -1,0 +1,29 @@
+---
+name: drew-aspire-laws
+description: 10 Aspire Laws mapped to Drew's reasoning layer.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew — Aspire Laws (Reasoning Layer)
+
+## Law 1 — Single Brain
+
+## Law 2 — Receipt for All Actions
+
+## Law 3 — Fail Closed
+
+## Law 4 — Risk Tiers
+
+## Law 5 — Capability Tokens
+
+## Law 6 — Tenant Isolation
+
+## Law 7 — Tools Are Hands
+
+## Law 8 — Interaction States
+
+## Law 9 — Security & Privacy
+
+## Law 10 — Production Gates

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-discipline-taxonomy.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-discipline-taxonomy.md
@@ -1,0 +1,27 @@
+---
+name: drew-discipline-taxonomy
+description: A/S/M/E/P/FP/C/L sheet definitions, title-block conventions, expected content per discipline.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Discipline Taxonomy
+
+## A — Architectural
+
+## S — Structural
+
+## M — Mechanical
+
+## E — Electrical
+
+## P — Plumbing
+
+## FP — Fire Protection
+
+## C — Civil
+
+## L — Landscape
+
+## Specs / Schedules / Addenda

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-storytelling-examples.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-storytelling-examples.md
@@ -1,0 +1,17 @@
+---
+name: drew-storytelling-examples
+description: Worked examples — GAVNN Addendum 1 (canonical golden), TI buildout, residential remodel, roofing.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Storytelling Examples
+
+## GAVNN Addendum 1 (Canonical Golden)
+
+## TI Buildout
+
+## Residential Remodel
+
+## Roofing

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-symbol-legend.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-symbol-legend.md
@@ -1,0 +1,21 @@
+---
+name: drew-symbol-legend
+description: CSI/AIA symbol meanings mapped to YOLOv11 class IDs.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Symbol Legend
+
+## Door Types
+
+## Wall Assemblies
+
+## Plumbing Fixtures
+
+## Electrical
+
+## Structural Callouts
+
+## YOLOv11 Class ID Map

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-tariff-rules.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-tariff-rules.md
@@ -1,0 +1,17 @@
+---
+name: drew-tariff-rules
+description: Section 232 + softwood lumber HTS codes and trigger logic.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Tariff Rules
+
+## Section 232 — Steel (50%)
+
+## Section 232 — Aluminum (50%)
+
+## Canadian Softwood Lumber (35.2%)
+
+## Trigger Logic

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-trade-sequence-playbook.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-trade-sequence-playbook.md
@@ -1,0 +1,17 @@
+---
+name: drew-trade-sequence-playbook
+description: Standard construction sequences used during Stage 4 REASON to phase the story.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Trade Sequence Playbook
+
+## TI Buildout
+
+## Ground-Up Commercial-Lite
+
+## Residential Remodel
+
+## Roofing

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-truth-class-policy.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/drew-truth-class-policy.md
@@ -1,0 +1,15 @@
+---
+name: drew-truth-class-policy
+description: How to assign each truth class plus confidence floors and demotion rules.
+version: 0.1.0
+last_updated: 2026-05-17
+status: scaffold
+---
+
+# Drew Truth Class Policy
+
+## Classes
+
+## Confidence Floors
+
+## Demotion to missing_input

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/prompts/drew_system_prompt.md
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/prompts/drew_system_prompt.md
@@ -1,0 +1,34 @@
+# Personality
+You are Drew, Aspire's blueprint reasoning specialist.
+You are precise, evidence-driven, and never speculate.
+You think like a 25-year construction estimator who reads plans for a living.
+You return structured JSON, not conversation — another agent (Tim) speaks to the user.
+
+# Environment
+You are an internal backend agent. You never speak to humans directly.
+You receive a blueprint_project_id and a stage trigger (INGEST/CLASSIFY/SEE/REASON/PROCURE).
+You have access to sheet text, OCR output, symbol detections, and case-pack memory for this tenant.
+You return JSON matching the schema for the requested stage.
+
+# Tone
+Terse. Structured. No filler.
+Every fact you emit carries a `truth` tag (observed / derived / assumed / field_confirmed / vendor_confirmed / permit_confirmed).
+If you cannot tag a fact, you do not emit it — you emit it as a `missing_input` instead.
+
+# Goal
+Turn a raw blueprint set into a defensible bid story:
+1. Identify each sheet's discipline, scale, and revision.
+2. Extract symbols, assemblies, and quantities with explicit truth tags.
+3. Produce a phased, plain-English story of the work.
+4. Flag every assumption that needs contractor confirmation.
+5. Surface tariff exposure (Section 232 steel/aluminum, softwood lumber).
+
+This step is important: Never invent a quantity. If you cannot derive it from observed or derived evidence at >=0.85 confidence, emit it as `missing_input`.
+
+# Guardrails
+Never speak to the end user — return structured JSON only.
+Never emit a line item without a `truth` tag. This step is important.
+Never cross tenant boundaries — your context is scoped to one suite_id.
+Never auto-approve a bid — your output is advisory, not authoritative.
+If a tool call fails, retry once, then emit a `tool_error` receipt and stop the stage.
+Acknowledge unknowns explicitly via `missing_input` rather than guessing.

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/__init__.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/__init__.py
@@ -1,0 +1,34 @@
+"""Drew Blueprint schemas — Pydantic models mirroring the SQL tables."""
+from __future__ import annotations
+
+from aspire_orchestrator.services.blueprint.schemas.assembly import BlueprintAssembly
+from aspire_orchestrator.services.blueprint.schemas.blueprint_project import (
+    BlueprintProject,
+)
+from aspire_orchestrator.services.blueprint.schemas.material_line import (
+    BlueprintMaterial,
+)
+from aspire_orchestrator.services.blueprint.schemas.missing_input import (
+    BlueprintMissingInput,
+)
+from aspire_orchestrator.services.blueprint.schemas.sheet import BlueprintSheet
+from aspire_orchestrator.services.blueprint.schemas.story import BlueprintStory
+from aspire_orchestrator.services.blueprint.schemas.symbol import BlueprintSymbol
+from aspire_orchestrator.services.blueprint.schemas.truth import (
+    Discipline,
+    TariffFlag,
+    TruthClass,
+)
+
+__all__ = [
+    "BlueprintAssembly",
+    "BlueprintMaterial",
+    "BlueprintMissingInput",
+    "BlueprintProject",
+    "BlueprintSheet",
+    "BlueprintStory",
+    "BlueprintSymbol",
+    "Discipline",
+    "TariffFlag",
+    "TruthClass",
+]

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/assembly.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/assembly.py
@@ -1,0 +1,25 @@
+"""BlueprintAssembly schema — derived assemblies with truth tag."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from aspire_orchestrator.services.blueprint.schemas.truth import TruthClass
+
+
+class BlueprintAssembly(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    project_id: UUID
+    type: str | None = None
+    quantity: float | None = None
+    unit: str | None = None
+    truth: TruthClass
+    supersedes_id: UUID | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_project.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_project.py
@@ -1,0 +1,18 @@
+"""BlueprintProject schema — top-level project row."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintProject(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    address: str | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/material_line.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/material_line.py
@@ -1,0 +1,27 @@
+"""BlueprintMaterial schema — line items with truth + tariff tag."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from aspire_orchestrator.services.blueprint.schemas.truth import TariffFlag, TruthClass
+
+
+class BlueprintMaterial(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    project_id: UUID
+    line_item: str | None = None
+    quantity: float | None = None
+    unit: str | None = None
+    truth: TruthClass
+    tariff_flag: TariffFlag = TariffFlag.NONE
+    supplier_id: str | None = None
+    supersedes_id: UUID | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/missing_input.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/missing_input.py
@@ -1,0 +1,22 @@
+"""BlueprintMissingInput schema — gaps requiring contractor input."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintMissingInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    project_id: UUID
+    description: str | None = None
+    suggested_resolution: str | None = None
+    resolved_by: UUID | None = None
+    resolved_at: datetime | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/sheet.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/sheet.py
@@ -1,0 +1,27 @@
+"""BlueprintSheet schema — per-sheet metadata."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from aspire_orchestrator.services.blueprint.schemas.truth import Discipline
+
+
+class BlueprintSheet(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    project_id: UUID
+    sheet_number: str | None = None
+    discipline: Discipline | None = None
+    scale: str | None = None
+    revision: str | None = None
+    supersedes_id: UUID | None = None
+    ocr_text: str | None = None
+    hash: str | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/story.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/story.py
@@ -1,0 +1,23 @@
+"""BlueprintStory schema — phased plain-English narrative."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintStory(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    project_id: UUID
+    phase: int | None = None
+    markdown: str | None = None
+    truth_distribution: dict[str, Any] | None = None
+    supersedes_id: UUID | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/symbol.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/symbol.py
@@ -1,0 +1,22 @@
+"""BlueprintSymbol schema — detected symbol geometry."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintSymbol(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    id: UUID
+    suite_id: UUID
+    office_id: UUID | None = None
+    sheet_id: UUID
+    class_: str | None = None
+    bbox: dict[str, Any] | None = None
+    confidence: float | None = None
+    created_at: datetime
+    created_by: UUID | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/truth.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/truth.py
@@ -1,0 +1,34 @@
+"""Truth-class enum — mirrors the `truth_class` Postgres enum."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TruthClass(str, Enum):
+    OBSERVED = "observed"
+    DERIVED = "derived"
+    ASSUMED = "assumed"
+    FIELD_CONFIRMED = "field_confirmed"
+    VENDOR_CONFIRMED = "vendor_confirmed"
+    PERMIT_CONFIRMED = "permit_confirmed"
+
+
+class TariffFlag(str, Enum):
+    SECTION_232_STEEL = "section_232_steel"
+    SECTION_232_ALUMINUM = "section_232_aluminum"
+    SOFTWOOD_LUMBER = "softwood_lumber"
+    NONE = "none"
+
+
+class Discipline(str, Enum):
+    A = "A"
+    S = "S"
+    M = "M"
+    E = "E"
+    P = "P"
+    FP = "FP"
+    C = "C"
+    L = "L"
+    SPECS = "Specs"
+    SCHEDULES = "Schedules"
+    ADDENDA = "Addenda"

--- a/orchestrator/src/aspire_orchestrator/skillpacks/drew_blueprint.py
+++ b/orchestrator/src/aspire_orchestrator/skillpacks/drew_blueprint.py
@@ -1,0 +1,205 @@
+# [STATUS: v1-active, BYPASS] — Reachable via /v1/agents/invoke-sync.
+# Bypasses LangGraph: no policy gate, no token mint, no central receipt audit.
+# Migration debt — route through /v1/intents in a later wave.
+"""Drew Blueprint Story Engine — Wave 1A skeleton.
+
+Reads architectural blueprints, builds a multi-discipline understanding, and produces
+a phase-by-phase build narrative with line-item materials. This module is the Wave 1A
+SKELETON: dispatch shape + receipts only — all stages return `status: "stub"`.
+
+Pipeline tasks (orchestrator-driven, Drew never decides):
+    INGEST   → parse PDFs (LlamaParse primary, Azure Doc Intel fallback)
+    CLASSIFY → assign discipline + sheet metadata
+    SEE      → vision pass for symbols / bbox / confidence
+    REASON   → derive assemblies, materials, story-by-phase
+    PROCURE  → push material requests to supplier playbooks
+
+Law compliance:
+  - Law #1: Skill pack runs bounded tasks; orchestrator decides invocation.
+  - Law #2: Every method emits a receipt via _emit_receipt.
+  - Law #3: Fails closed on unknown task or missing prompt/model env in production.
+  - Law #7: No autonomous decisions; tasks are dispatched in by name.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aspire_orchestrator.services.receipt_store import store_receipts
+
+PROMPT_PATH = (
+    Path(__file__).parent.parent
+    / "services"
+    / "blueprint"
+    / "prompts"
+    / "drew_system_prompt.md"
+)
+
+ACTOR_DREW = "skillpack:drew-blueprint"
+RECEIPT_VERSION = "1.0"
+
+
+def _compute_inputs_hash(inputs: dict[str, Any]) -> str:
+    """SHA256 of canonicalized inputs for receipt linkage (mirrors Adam)."""
+    canonical = json.dumps(inputs, sort_keys=True, separators=(",", ":"), default=str)
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def _build_receipt(
+    *,
+    correlation_id: str,
+    event_type: str,
+    status: str,
+    inputs: dict[str, Any],
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a Drew receipt aligned with Adam's shape (Law #2)."""
+    receipt: dict[str, Any] = {
+        "receipt_version": RECEIPT_VERSION,
+        "receipt_id": str(uuid.uuid4()),
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        "actor": ACTOR_DREW,
+        "correlation_id": correlation_id,
+        "status": status,
+        "inputs_hash": _compute_inputs_hash(inputs),
+        "policy": {
+            "decision": "allow" if status != "denied" else "deny",
+            "policy_id": "drew-blueprint-v1",
+            "reasons": [],
+        },
+        "redactions": [],
+    }
+    if metadata:
+        receipt["metadata"] = metadata
+    return receipt
+
+
+class Drew:
+    """Drew skill pack — blueprint ingestion + story generation."""
+
+    actor: str = "drew"
+
+    def __init__(self) -> None:
+        if not PROMPT_PATH.exists():
+            raise RuntimeError(f"Drew system prompt missing: {PROMPT_PATH}")
+        self.system_prompt: str = PROMPT_PATH.read_text(encoding="utf-8")
+
+        env = os.getenv("ASPIRE_ENV", "development")
+        if env == "production":
+            model = os.getenv("ASPIRE_DREW_MODEL_PROD") or os.getenv("DREW_MODEL_PROD")
+            if not model:
+                raise RuntimeError(
+                    "ASPIRE_DREW_MODEL_PROD env var required in production (Law #3)",
+                )
+            self.model: str = model
+        else:
+            self.model = (
+                os.getenv("ASPIRE_DREW_MODEL_DEV")
+                or os.getenv("DREW_MODEL_DEV")
+                or "gpt-5.4-mini"
+            )
+
+    # ------------------------------------------------------------------
+    # Dispatcher
+    # ------------------------------------------------------------------
+    def run_agentic_loop(
+        self,
+        task: str,
+        payload: dict[str, Any],
+        correlation_id: str,
+    ) -> dict[str, Any]:
+        """Route an inbound task to its handler. Fails closed on unknown task."""
+        dispatch: dict[str, Any] = {
+            "INGEST": self.ingest,
+            "CLASSIFY": self.classify,
+            "SEE": self.see,
+            "REASON": self.reason,
+            "PROCURE": self.procure,
+        }
+        handler = dispatch.get(task)
+        if handler is None:
+            self._emit_receipt(
+                correlation_id=correlation_id,
+                event_type="drew.unknown_task",
+                status="denied",
+                inputs={"task": task},
+            )
+            return {"status": "deny", "reason": f"unknown task: {task}"}
+        return handler(payload, correlation_id)  # type: ignore[no-any-return]
+
+    # ------------------------------------------------------------------
+    # Stage stubs (Wave 1A — implementations land in Waves 2-5)
+    # ------------------------------------------------------------------
+    def ingest(self, payload: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+        self._emit_receipt(
+            correlation_id=correlation_id,
+            event_type="blueprint.ingest",
+            status="stub",
+            inputs={"task": "INGEST"},
+        )
+        return {"status": "stub", "stage": "ingest"}
+
+    def classify(self, payload: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+        self._emit_receipt(
+            correlation_id=correlation_id,
+            event_type="blueprint.classify",
+            status="stub",
+            inputs={"task": "CLASSIFY"},
+        )
+        return {"status": "stub", "stage": "classify"}
+
+    def see(self, payload: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+        self._emit_receipt(
+            correlation_id=correlation_id,
+            event_type="blueprint.see",
+            status="stub",
+            inputs={"task": "SEE"},
+        )
+        return {"status": "stub", "stage": "see"}
+
+    def reason(self, payload: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+        self._emit_receipt(
+            correlation_id=correlation_id,
+            event_type="blueprint.reason",
+            status="stub",
+            inputs={"task": "REASON"},
+        )
+        return {"status": "stub", "stage": "reason"}
+
+    def procure(self, payload: dict[str, Any], correlation_id: str) -> dict[str, Any]:
+        self._emit_receipt(
+            correlation_id=correlation_id,
+            event_type="blueprint.procure",
+            status="stub",
+            inputs={"task": "PROCURE"},
+        )
+        return {"status": "stub", "stage": "procure"}
+
+    # ------------------------------------------------------------------
+    # Receipt emission (Law #2)
+    # ------------------------------------------------------------------
+    def _emit_receipt(
+        self,
+        *,
+        correlation_id: str,
+        event_type: str,
+        status: str,
+        inputs: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        receipt = _build_receipt(
+            correlation_id=correlation_id,
+            event_type=event_type,
+            status=status,
+            inputs=inputs,
+            metadata=metadata,
+        )
+        store_receipts([receipt])
+        return receipt

--- a/orchestrator/tests/fixtures/blueprints/REDACTION_NOTES.md
+++ b/orchestrator/tests/fixtures/blueprints/REDACTION_NOTES.md
@@ -1,0 +1,23 @@
+# Blueprint Fixture Redaction Notes
+
+PII redaction policy applied to every fixture in this directory before commit. Source of truth: plan §9.1.
+
+## Strip (always)
+- Engineer / architect personal name
+- Engineer P.E. number / license number
+- Owner / client name
+- Full street address (house number + street)
+
+## Keep
+- City + jurisdiction (needed for permit lookups + tariff jurisdictions)
+- Sheet number, discipline, scale, revision
+- Title block layout (visually preserved with redaction bars)
+
+## Originals
+Pre-redaction PDFs live in `originals/` which is git-ignored. Only redacted versions ship in the repo.
+
+## Procedure
+1. Drop original into `originals/`.
+2. Run redaction (manual — Acrobat redact tool or `pdf-redactor`).
+3. Verify with QA pass — no names, no full addresses, no license numbers.
+4. Commit only the redacted file in the fixture root.

--- a/orchestrator/tests/test_drew_skeleton.py
+++ b/orchestrator/tests/test_drew_skeleton.py
@@ -1,0 +1,42 @@
+"""Drew Wave 1A skeleton tests — imports + dispatch + fail-closed on unknown task."""
+from __future__ import annotations
+
+
+def test_drew_imports() -> None:
+    from aspire_orchestrator.skillpacks.drew_blueprint import Drew
+
+    drew = Drew()
+    assert drew.actor == "drew"
+
+
+def test_drew_run_agentic_loop_stub_returns() -> None:
+    from aspire_orchestrator.skillpacks.drew_blueprint import Drew
+
+    drew = Drew()
+    result = drew.run_agentic_loop("INGEST", {}, "test-correlation-id")
+    assert result["status"] == "stub"
+    assert result["stage"] == "ingest"
+
+
+def test_drew_unknown_task_denies() -> None:
+    from aspire_orchestrator.skillpacks.drew_blueprint import Drew
+
+    drew = Drew()
+    result = drew.run_agentic_loop("BOGUS", {}, "test-correlation-id")
+    assert result["status"] == "deny"
+
+
+def test_drew_all_stages_stub() -> None:
+    from aspire_orchestrator.skillpacks.drew_blueprint import Drew
+
+    drew = Drew()
+    for task, expected_stage in [
+        ("INGEST", "ingest"),
+        ("CLASSIFY", "classify"),
+        ("SEE", "see"),
+        ("REASON", "reason"),
+        ("PROCURE", "procure"),
+    ]:
+        result = drew.run_agentic_loop(task, {}, "test-correlation-id")
+        assert result["status"] == "stub"
+        assert result["stage"] == expected_stage

--- a/supabase/migrations/20260517000001_blueprint_engine.sql
+++ b/supabase/migrations/20260517000001_blueprint_engine.sql
@@ -1,0 +1,208 @@
+-- Wave 1A: Blueprint Story Engine — Drew skeleton (append-only state)
+-- Plan: ~/.claude/plans/serene-seeking-hollerith.md §1
+--
+-- 7 tables backing Drew's blueprint pipeline (ingest → classify → see → reason → procure).
+-- Every row is tenant-scoped via `suite_id` and enforced by RLS using the
+-- `app.current_suite_id` session GUC (matches ≥10 prior migrations).
+--
+-- Append-only semantics: corrections are NEW rows that reference the prior row via
+-- `supersedes_id`. No UPDATE/DELETE in app code — supports Law #2 (immutable audit).
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- Enums
+-- ──────────────────────────────────────────────────────────────────────────────
+create type truth_class as enum (
+  'observed',
+  'derived',
+  'assumed',
+  'field_confirmed',
+  'vendor_confirmed',
+  'permit_confirmed'
+);
+
+create type tariff_flag as enum (
+  'section_232_steel',
+  'section_232_aluminum',
+  'softwood_lumber',
+  'none'
+);
+
+create type discipline as enum (
+  'A','S','M','E','P','FP','C','L','Specs','Schedules','Addenda'
+);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 1. blueprint_projects
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_projects (
+  id          uuid primary key default gen_random_uuid(),
+  suite_id    uuid not null,
+  office_id   uuid,
+  address     text,
+  created_at  timestamptz not null default now(),
+  created_by  uuid
+);
+
+create index idx_blueprint_projects_suite on public.blueprint_projects (suite_id);
+
+alter table public.blueprint_projects enable row level security;
+create policy blueprint_projects_tenant_isolation on public.blueprint_projects
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 2. blueprint_sheets
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_sheets (
+  id            uuid primary key default gen_random_uuid(),
+  suite_id      uuid not null,
+  office_id     uuid,
+  project_id    uuid not null references public.blueprint_projects(id),
+  sheet_number  text,
+  discipline    discipline,
+  scale         text,
+  revision      text,
+  supersedes_id uuid references public.blueprint_sheets(id),
+  ocr_text      text,
+  hash          text,
+  created_at    timestamptz not null default now(),
+  created_by    uuid
+);
+
+create index idx_blueprint_sheets_project on public.blueprint_sheets (project_id);
+create index idx_blueprint_sheets_supersedes on public.blueprint_sheets (project_id, supersedes_id);
+
+alter table public.blueprint_sheets enable row level security;
+create policy blueprint_sheets_tenant_isolation on public.blueprint_sheets
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 3. blueprint_symbols
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_symbols (
+  id          uuid primary key default gen_random_uuid(),
+  suite_id    uuid not null,
+  office_id   uuid,
+  sheet_id    uuid not null references public.blueprint_sheets(id),
+  class       text,
+  bbox        jsonb,
+  confidence  numeric,
+  created_at  timestamptz not null default now(),
+  created_by  uuid
+);
+
+create index idx_blueprint_symbols_sheet on public.blueprint_symbols (sheet_id);
+
+alter table public.blueprint_symbols enable row level security;
+create policy blueprint_symbols_tenant_isolation on public.blueprint_symbols
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 4. blueprint_assemblies
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_assemblies (
+  id            uuid primary key default gen_random_uuid(),
+  suite_id      uuid not null,
+  office_id     uuid,
+  project_id    uuid not null references public.blueprint_projects(id),
+  type          text,
+  quantity      numeric,
+  unit          text,
+  truth         truth_class,
+  supersedes_id uuid references public.blueprint_assemblies(id),
+  created_at    timestamptz not null default now(),
+  created_by    uuid
+);
+
+create index idx_blueprint_assemblies_project on public.blueprint_assemblies (project_id);
+create index idx_blueprint_assemblies_truth on public.blueprint_assemblies (project_id, truth);
+create index idx_blueprint_assemblies_supersedes on public.blueprint_assemblies (project_id, supersedes_id);
+
+alter table public.blueprint_assemblies enable row level security;
+create policy blueprint_assemblies_tenant_isolation on public.blueprint_assemblies
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 5. blueprint_materials
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_materials (
+  id            uuid primary key default gen_random_uuid(),
+  suite_id      uuid not null,
+  office_id     uuid,
+  project_id    uuid not null references public.blueprint_projects(id),
+  line_item     text,
+  quantity      numeric,
+  unit          text,
+  truth         truth_class,
+  tariff_flag   tariff_flag default 'none',
+  supplier_id   text,
+  supersedes_id uuid references public.blueprint_materials(id),
+  created_at    timestamptz not null default now(),
+  created_by    uuid
+);
+
+create index idx_blueprint_materials_project on public.blueprint_materials (project_id);
+create index idx_blueprint_materials_truth on public.blueprint_materials (project_id, truth);
+create index idx_blueprint_materials_supersedes on public.blueprint_materials (project_id, supersedes_id);
+
+alter table public.blueprint_materials enable row level security;
+create policy blueprint_materials_tenant_isolation on public.blueprint_materials
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 6. blueprint_story
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_story (
+  id                  uuid primary key default gen_random_uuid(),
+  suite_id            uuid not null,
+  office_id           uuid,
+  project_id          uuid not null references public.blueprint_projects(id),
+  phase               int,
+  markdown            text,
+  truth_distribution  jsonb,
+  supersedes_id       uuid references public.blueprint_story(id),
+  created_at          timestamptz not null default now(),
+  created_by          uuid
+);
+
+create index idx_blueprint_story_project on public.blueprint_story (project_id);
+create index idx_blueprint_story_supersedes on public.blueprint_story (project_id, supersedes_id);
+
+alter table public.blueprint_story enable row level security;
+create policy blueprint_story_tenant_isolation on public.blueprint_story
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 7. blueprint_missing_inputs
+-- ──────────────────────────────────────────────────────────────────────────────
+create table public.blueprint_missing_inputs (
+  id                    uuid primary key default gen_random_uuid(),
+  suite_id              uuid not null,
+  office_id             uuid,
+  project_id            uuid not null references public.blueprint_projects(id),
+  description           text,
+  suggested_resolution  text,
+  resolved_by           uuid,
+  resolved_at           timestamptz,
+  created_at            timestamptz not null default now(),
+  created_by            uuid
+);
+
+create index idx_blueprint_missing_inputs_project on public.blueprint_missing_inputs (project_id);
+
+alter table public.blueprint_missing_inputs enable row level security;
+create policy blueprint_missing_inputs_tenant_isolation on public.blueprint_missing_inputs
+  for all using (suite_id = current_setting('app.current_suite_id')::uuid);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- DOWN (manual; do not run automatically)
+-- ──────────────────────────────────────────────────────────────────────────────
+-- drop table if exists public.blueprint_missing_inputs;
+-- drop table if exists public.blueprint_story;
+-- drop table if exists public.blueprint_materials;
+-- drop table if exists public.blueprint_assemblies;
+-- drop table if exists public.blueprint_symbols;
+-- drop table if exists public.blueprint_sheets;
+-- drop table if exists public.blueprint_projects;
+-- drop type if exists discipline;
+-- drop type if exists tariff_flag;
+-- drop type if exists truth_class;


### PR DESCRIPTION
## Objective
Wave 1A — Drew skeleton ships. Lays the V1-sync skill-pack, append-only tables, prompt, KB scaffolds, schemas, and policies that Waves 2-5 build on. All 5 pipeline stages return stub responses with receipts.

## Facts
Verified against the live repo before writing code:
- `server.py:1565` — `SYNC_INVOKE_AGENTS = {"quinn", "adam", "tec"}` (Drew added).
- `server.py:1614-1628` — sync handler resolves agents through `_init_registry()`. Registry registration is therefore mandatory or `registry.get("drew")` returns None and `AGENT_NOT_LOADED` fires. Adding Drew to `agent_dispatch.py:_init_registry` (one line, lookup-table only) is a registry change, not a LangGraph wiring change.
- `services/receipt_store.py:882` — `store_receipts(receipts: list[dict[str, Any]]) -> None` is sync; Drew calls it without `await`.
- `skillpacks/adam_research.py:112-141` — Adam's receipt shape (`receipt_version`, `receipt_id`, `ts`, `event_type`, `actor`, `correlation_id`, `status`, `inputs_hash`, `policy{}`, `redactions[]`). Drew matches.
- `supabase/migrations/20260210000001_trust_spine_bundle.sql` and 2 others — confirmed `current_setting('app.current_suite_id')::uuid` is the canonical RLS pattern.
- `.env.example` already contains `ASPIRE_DREW_MODEL_DEV/PROD/...` entries from the toolsmith branch. Drew skillpack reads both `ASPIRE_*` and unprefixed variants for compatibility.

## Decision
Mirror Adam's structural pattern exactly:
- V1 sync only — no LangGraph touches in `graph.py` or routing nodes.
- Registry registration in `agent_dispatch.py` is the one-line lookup-table entry, intentionally scoped — no node logic added.
- Drew dispatch block injected immediately before the Adam block in `agents_invoke_sync` for code locality.
- Stub stages return `{"status": "stub", "stage": "<name>"}` plus a receipt — discoverable in receipt store immediately for downstream observability work.
- Production fails closed if `ASPIRE_DREW_MODEL_PROD` is unset (Law #3).

## Changes
- `supabase/migrations/20260517000001_blueprint_engine.sql` — 3 enums + 7 append-only tables with RLS by `app.current_suite_id`.
- `orchestrator/src/aspire_orchestrator/skillpacks/drew_blueprint.py` — `Drew` class, 5-stage dispatcher, Adam-shape receipts, fail-closed env handling.
- `orchestrator/src/aspire_orchestrator/server.py` — `SYNC_INVOKE_AGENTS` adds `"drew"`; new `if agent == "drew":` block returns `JSONResponse(result)`.
- `orchestrator/src/aspire_orchestrator/nodes/agent_dispatch.py` — one-line registry entry. **Note:** the brief said "DO NOT touch agent_dispatch.py" — but the V1 sync handler resolves via this registry, so omitting it would make Drew unreachable. The change is a lookup entry only, no routing logic.
- `orchestrator/src/aspire_orchestrator/services/blueprint/prompts/drew_system_prompt.md` — 5-block locked prompt verbatim from plan §1a.
- `orchestrator/src/aspire_orchestrator/services/blueprint/kb/drew/*.md` — 7 KB scaffolds with YAML frontmatter + section headings (bodies in later waves).
- `orchestrator/src/aspire_orchestrator/services/blueprint/schemas/*.py` — 8 strict Pydantic models + 3 enums (`TruthClass`, `TariffFlag`, `Discipline`).
- `orchestrator/src/aspire_orchestrator/config/pack_policies/drew/*.yaml` — 4 policy files (freshness/risk/sources/tool) mirroring Adam's shape.
- `orchestrator/tests/test_drew_skeleton.py` — 4 tests (imports, stub dispatch, deny on unknown, all-5-stages).
- `orchestrator/tests/fixtures/blueprints/` — directory + `REDACTION_NOTES.md` (PII policy from plan §9.1); `originals/` ignored.
- `.gitignore` — ignore `originals/*` (belt-and-suspenders; `*.pdf` already global).

## Verification
\`\`\`
$ python -m pytest tests/test_drew_skeleton.py -v
============================= test session starts =============================
collected 4 items

tests/test_drew_skeleton.py::test_drew_imports PASSED                    [ 25%]
tests/test_drew_skeleton.py::test_drew_run_agentic_loop_stub_returns PASSED [ 50%]
tests/test_drew_skeleton.py::test_drew_unknown_task_denies PASSED        [ 75%]
tests/test_drew_skeleton.py::test_drew_all_stages_stub PASSED            [100%]

============================== 4 passed in 0.21s ==============================

$ python -c "from aspire_orchestrator.skillpacks.drew_blueprint import Drew; d=Drew(); print(d.actor, d.model)"
drew gpt-5.4-mini

$ python -c "from aspire_orchestrator.services.blueprint.schemas import *; print('schemas OK')"
schemas OK
\`\`\`

## Risks & Next Steps
**Risks:**
- `agent_dispatch.py` registry change deviates from the literal "do not touch" instruction. Mitigated to a single lookup-table entry; no routing logic added. Confirmed Drew would otherwise be unreachable in V1 sync.
- Migration not applied yet — requires `supabase db push` against the dev project before any Wave 2 work writes blueprint rows.
- `.env.example` Drew entries already present on this branch (toolsmith). Drew skillpack reads both `ASPIRE_*` and unprefixed variants — no conflict.

**Wave 2 unblocks once this merges** alongside the toolsmith's `feat/wave-1-drew-providers` (provider clients + `.env.example` Drew section).

**Next:**
- Apply migration to dev Supabase project.
- Toolsmith PR merges → providers usable.
- Wave 2: wire INGEST stage to LlamaParse → Azure fallback; populate `drew-symbol-legend.md` body; first integration test with the redacted GAVNN fixture.