### PR TITLE
feat(blueprints): Wave 2.7 — Scope + Takeoff read APIs + missing_input resolve

### DIFF
--- a/orchestrator/src/aspire_orchestrator/routes/blueprints.py
+++ b/orchestrator/src/aspire_orchestrator/routes/blueprints.py
@@ -1,21 +1,31 @@
-"""Blueprint read API routes — Wave 2.5.
+"""Blueprint read API routes — Wave 2.5 + Wave 2.7.
 
-Routes:
+Routes (Wave 2.5):
   GET /v1/blueprints/projects/{project_id}         — project + sheet_count + stage_progress
   GET /v1/blueprints/projects/{project_id}/sheets  — list sheets (filterable + dedup-aware)
   GET /v1/blueprints/projects/{project_id}/status  — lightweight status for frontend polling
 
-Law compliance:
-  Law #2 — receipt cut on every read (even GREEN tier reads get receipts in Aspire).
-  Law #3 — fail closed: missing scope headers → 401. RLS hides row → 404 (not 403).
-  Law #4 — GREEN tier: read-only, no state changes.
-  Law #6 — tenant isolation: suite_id set via SET LOCAL before every query; RLS
-            enforces it at DB layer. Cross-tenant attempt returns 404, not 403,
-            to avoid existence leaks.
-  Law #9 — no PII in logs or receipts.
+Routes (Wave 2.7 — Scope tab + Takeoff tab):
+  GET  /v1/blueprints/projects/{project_id}/symbols          — symbols per sheet or project
+  GET  /v1/blueprints/projects/{project_id}/assemblies       — derived assemblies
+  GET  /v1/blueprints/projects/{project_id}/materials        — material line items
+  GET  /v1/blueprints/projects/{project_id}/missing_inputs   — contractor input gaps
+  GET  /v1/blueprints/projects/{project_id}/story            — phased narrative
+  POST /v1/blueprints/projects/{project_id}/missing_inputs/{input_id}/resolve
+                                                             — resolve a gap (YELLOW)
 
-Auth pattern: X-Tenant-Id / X-Suite-Id / X-Office-Id headers (set by API Gateway,
-identical to contacts.py, voicemails.py, callbacks.py pattern in this codebase).
+Law compliance:
+  Law #2 — receipt cut on every read AND on every state-change (success + failure).
+  Law #3 — fail closed: missing scope headers → 401, missing capability token → 401.
+  Law #4 — POST /resolve is YELLOW tier: requires capability_token in request body.
+           GREEN tier: all GET endpoints (no state change, no token required).
+  Law #6 — tenant isolation: suite_id enforced in every query filter.
+           Cross-tenant attempt returns 404, not 403 (no existence leak).
+  Law #9 — markdown body, supplier name/address NEVER appear in receipts or logs.
+           Only counts and opaque IDs are logged.
+
+Auth pattern: X-Tenant-Id / X-Suite-Id / X-Office-Id headers (identical to
+contacts.py, voicemails.py, callbacks.py pattern in this codebase).
 """
 
 from __future__ import annotations
@@ -25,12 +35,21 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException, Query, status
+from fastapi import APIRouter, Body, Header, HTTPException, Query, status
 
 from aspire_orchestrator.middleware.correlation import get_correlation_id, get_trace_id
 from aspire_orchestrator.routes._scope import _resolve_scope
 from aspire_orchestrator.schemas.memory_v1 import ScopedIdentity
 from aspire_orchestrator.services import receipt_store
+from aspire_orchestrator.services.blueprint.schemas.blueprint_assembly_read import (
+    BlueprintAssemblyRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_material_read import (
+    BlueprintMaterialRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_missing_input_read import (
+    BlueprintMissingInputRead,
+)
 from aspire_orchestrator.services.blueprint.schemas.blueprint_project_read import (
     BlueprintProjectRead,
 )
@@ -40,9 +59,21 @@ from aspire_orchestrator.services.blueprint.schemas.blueprint_project_status imp
 from aspire_orchestrator.services.blueprint.schemas.blueprint_sheet_read import (
     BlueprintSheetRead,
 )
+from aspire_orchestrator.services.blueprint.schemas.blueprint_story_read import (
+    BlueprintStoryPhase,
+    BlueprintStoryRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_symbol_read import (
+    BlueprintSymbolRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+    MissingInputResolveRequest,
+)
+from aspire_orchestrator.services.blueprint.schemas.truth import TruthClass
 from aspire_orchestrator.services.supabase_client import (
     SupabaseClientError,
     supabase_select,
+    supabase_update,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,6 +89,7 @@ def _cut_receipt(
     *,
     scope: ScopedIdentity,
     action_type: str,
+    risk_tier: str = "green",
     outcome: str = "success",
     redacted_inputs: dict[str, Any] | None = None,
     redacted_outputs: dict[str, Any] | None = None,
@@ -75,7 +107,7 @@ def _cut_receipt(
                 "tenant_id": str(scope.tenant_id),
                 "outcome": outcome,
                 "tool_used": "blueprints_route",
-                "risk_tier": "green",
+                "risk_tier": risk_tier,
                 "redacted_inputs": redacted_inputs or {},
                 "redacted_outputs": redacted_outputs or {},
                 "trace_id": get_trace_id(),
@@ -85,6 +117,59 @@ def _cut_receipt(
         ]
     )
     return rid
+
+
+# ---------------------------------------------------------------------------
+# Shared project-existence check (DRY helper used by all Wave 2.7 endpoints)
+# ---------------------------------------------------------------------------
+
+async def _require_project(
+    project_id: str,
+    suite_id: str,
+    scope: ScopedIdentity,
+    action_type: str,
+) -> dict[str, Any]:
+    """Load and return the project row, or raise 404 (Law #3 / Law #6).
+
+    Emits a failure receipt on DB error or on not-found.
+    """
+    try:
+        rows = await supabase_select(
+            "blueprint_projects",
+            filters=f"id=eq.{project_id}&suite_id=eq.{suite_id}",
+            limit=1,
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.require_project: DB error action=%s project=%s suite=%s error=%s",
+            action_type,
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type=action_type,
+            outcome="failed",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    if not rows:
+        _cut_receipt(
+            scope=scope,
+            action_type=action_type,
+            outcome="not_found",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    return rows[0]
+
+
+# ===========================================================================
+# Wave 2.5 endpoints
+# ===========================================================================
 
 
 # ---------------------------------------------------------------------------
@@ -430,3 +515,645 @@ async def get_blueprint_status(
         symbol_count=symbol_count,
         missing_input_count=missing_input_count,
     )
+
+
+# ===========================================================================
+# Wave 2.7 endpoints
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/blueprints/projects/{project_id}/symbols
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/projects/{project_id}/symbols",
+    response_model=list[BlueprintSymbolRead],
+    summary="List blueprint symbols (Takeoff tab)",
+)
+async def list_blueprint_symbols(
+    project_id: str,
+    sheet_id: str | None = Query(None, description="Filter to one sheet"),
+    confidence_floor: float = Query(0.70, description="Minimum confidence threshold (default: 0.70)"),
+    class_prefix: str | None = Query(None, description="Filter by class prefix e.g. 'electrical_'"),
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> list[BlueprintSymbolRead]:
+    """List detected symbols for a blueprint project.
+
+    Symbols are detected by Drew SEE (Wave 3).  Filtered by confidence_floor
+    to reduce low-quality detections on the Takeoff tab.
+
+    Returns 404 when project is not visible to the requesting tenant (Law #6).
+    Emits blueprint.read.symbols receipt (Law #2).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    # Verify project ownership (Law #6) — emits failure receipt on error
+    await _require_project(project_id, suite_id, scope, "blueprint.read.symbols")
+
+    # Build symbol filter — suite_id always present (RLS belt-and-suspenders)
+    filter_parts = [f"suite_id=eq.{suite_id}"]
+
+    if sheet_id:
+        filter_parts.append(f"sheet_id=eq.{sheet_id}")
+    else:
+        # Scope to project via its sheets — join done client-side via sheet_id IN list.
+        # For now: filter by suite_id only (RLS enforces isolation) and post-filter.
+        # The PostgREST `sheet_id=in.(...)` form is used when we have sheet IDs.
+        try:
+            sheet_rows = await supabase_select(
+                "blueprint_sheets",
+                filters=f"project_id=eq.{project_id}&suite_id=eq.{suite_id}",
+            )
+            if sheet_rows:
+                sheet_ids = ",".join(str(r["id"]) for r in sheet_rows)
+                filter_parts.append(f"sheet_id=in.({sheet_ids})")
+            else:
+                # No sheets → no symbols
+                _cut_receipt(
+                    scope=scope,
+                    action_type="blueprint.read.symbols",
+                    outcome="success",
+                    redacted_inputs={"project_id": project_id, "sheet_id": sheet_id},
+                    redacted_outputs={"symbol_count": 0},
+                )
+                return []
+        except SupabaseClientError:
+            pass  # Fall through — will return empty if DB unreachable
+
+    # Confidence floor — PostgREST gte filter
+    filter_parts.append(f"confidence=gte.{confidence_floor}")
+
+    filter_str = "&".join(filter_parts)
+
+    try:
+        rows = await supabase_select(
+            "blueprint_symbols",
+            filters=filter_str,
+            order_by="confidence.desc",
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.list_symbols: DB error project=%s suite=%s error=%s",
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.read.symbols",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id, "sheet_id": sheet_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    # Optional: class_prefix post-filter (PostgREST lacks LIKE on non-text columns)
+    if class_prefix:
+        rows = [r for r in rows if (r.get("class_") or r.get("class", "") or "").startswith(class_prefix)]
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.read.symbols",
+        outcome="success",
+        redacted_inputs={"project_id": project_id, "sheet_id": sheet_id, "confidence_floor": confidence_floor},
+        redacted_outputs={"symbol_count": len(rows)},
+    )
+
+    return [
+        BlueprintSymbolRead(
+            id=row["id"],
+            sheet_id=row["sheet_id"],
+            class_=row.get("class_") or row.get("class"),
+            bbox=row.get("bbox"),
+            confidence=row.get("confidence"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/blueprints/projects/{project_id}/assemblies
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/projects/{project_id}/assemblies",
+    response_model=list[BlueprintAssemblyRead],
+    summary="List blueprint assemblies (Scope tab)",
+)
+async def list_blueprint_assemblies(
+    project_id: str,
+    active_only: bool = Query(True, description="Exclude superseded assemblies (default: true)"),
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> list[BlueprintAssemblyRead]:
+    """List derived assemblies for a blueprint project.
+
+    Assemblies are produced by Drew REASON (Wave 4).  By default excludes
+    superseded rows so the Scope tab always shows the current version.
+
+    Returns 404 when project is not visible to the requesting tenant (Law #6).
+    Emits blueprint.read.assemblies receipt (Law #2).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    await _require_project(project_id, suite_id, scope, "blueprint.read.assemblies")
+
+    filter_parts = [
+        f"project_id=eq.{project_id}",
+        f"suite_id=eq.{suite_id}",
+    ]
+    if active_only:
+        filter_parts.append("supersedes_id=is.null")
+
+    filter_str = "&".join(filter_parts)
+
+    try:
+        rows = await supabase_select(
+            "blueprint_assemblies",
+            filters=filter_str,
+            order_by="created_at.desc",
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.list_assemblies: DB error project=%s suite=%s error=%s",
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.read.assemblies",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.read.assemblies",
+        outcome="success",
+        redacted_inputs={"project_id": project_id, "active_only": active_only},
+        redacted_outputs={"assembly_count": len(rows)},
+    )
+
+    return [
+        BlueprintAssemblyRead(
+            id=row["id"],
+            type=row.get("type"),
+            quantity=row.get("quantity"),
+            unit=row.get("unit"),
+            truth=row["truth"],
+            supersedes_id=row.get("supersedes_id"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/blueprints/projects/{project_id}/materials
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/projects/{project_id}/materials",
+    response_model=list[BlueprintMaterialRead],
+    summary="List blueprint materials (Scope tab)",
+)
+async def list_blueprint_materials(
+    project_id: str,
+    tariff_only: bool = Query(False, description="Filter to tariff-flagged materials only"),
+    has_supplier: bool = Query(False, description="Filter to materials with a supplier assigned"),
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> list[BlueprintMaterialRead]:
+    """List material line items for a blueprint project.
+
+    Produced by Drew REASON (Wave 4); supplier_id populated by PROCURE (Wave 5).
+    Supports tariff_only and has_supplier filters for the Scope tab.
+
+    Law #9: supplier address / business name are NOT returned here.
+    Only the opaque supplier_id UUID is included.
+
+    Returns 404 when project is not visible to the requesting tenant (Law #6).
+    Emits blueprint.read.materials receipt (Law #2).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    await _require_project(project_id, suite_id, scope, "blueprint.read.materials")
+
+    filter_parts = [
+        f"project_id=eq.{project_id}",
+        f"suite_id=eq.{suite_id}",
+        # Active only — Wave 5 PROCURE always supersedes, so exclude stale rows
+        "supersedes_id=is.null",
+    ]
+
+    # tariff_only: exclude rows where tariff_flag = 'none'
+    if tariff_only:
+        filter_parts.append("tariff_flag=neq.none")
+
+    # has_supplier: exclude rows with no supplier_id
+    if has_supplier:
+        filter_parts.append("supplier_id=not.is.null")
+
+    filter_str = "&".join(filter_parts)
+
+    try:
+        rows = await supabase_select(
+            "blueprint_materials",
+            filters=filter_str,
+            order_by="created_at.desc",
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.list_materials: DB error project=%s suite=%s error=%s",
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.read.materials",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.read.materials",
+        outcome="success",
+        # Law #9: never log supplier_id values or line_item text in receipt outputs
+        redacted_inputs={"project_id": project_id, "tariff_only": tariff_only, "has_supplier": has_supplier},
+        redacted_outputs={"material_count": len(rows)},
+    )
+
+    return [
+        BlueprintMaterialRead(
+            id=row["id"],
+            line_item=row.get("line_item"),
+            quantity=row.get("quantity"),
+            unit=row.get("unit"),
+            truth=row["truth"],
+            tariff_flag=row.get("tariff_flag", "none"),
+            supplier_id=row.get("supplier_id"),
+            supersedes_id=row.get("supersedes_id"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/blueprints/projects/{project_id}/missing_inputs
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/projects/{project_id}/missing_inputs",
+    response_model=list[BlueprintMissingInputRead],
+    summary="List blueprint missing inputs (Scope tab)",
+)
+async def list_blueprint_missing_inputs(
+    project_id: str,
+    unresolved_only: bool = Query(True, description="Exclude resolved inputs (default: true)"),
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> list[BlueprintMissingInputRead]:
+    """List contractor input gaps for a blueprint project.
+
+    By default returns only unresolved gaps (resolved_at IS NULL).
+    Set unresolved_only=false to see all inputs including resolved ones.
+
+    Returns 404 when project is not visible to the requesting tenant (Law #6).
+    Emits blueprint.read.missing_inputs receipt (Law #2).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    await _require_project(project_id, suite_id, scope, "blueprint.read.missing_inputs")
+
+    filter_parts = [
+        f"project_id=eq.{project_id}",
+        f"suite_id=eq.{suite_id}",
+    ]
+
+    if unresolved_only:
+        filter_parts.append("resolved_at=is.null")
+
+    filter_str = "&".join(filter_parts)
+
+    try:
+        rows = await supabase_select(
+            "blueprint_missing_inputs",
+            filters=filter_str,
+            order_by="created_at.asc",
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.list_missing_inputs: DB error project=%s suite=%s error=%s",
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.read.missing_inputs",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.read.missing_inputs",
+        outcome="success",
+        redacted_inputs={"project_id": project_id, "unresolved_only": unresolved_only},
+        redacted_outputs={"missing_input_count": len(rows)},
+    )
+
+    return [
+        BlueprintMissingInputRead(
+            id=row["id"],
+            description=row.get("description"),
+            suggested_resolution=row.get("suggested_resolution"),
+            resolved_by=row.get("resolved_by"),
+            resolved_at=row.get("resolved_at"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/blueprints/projects/{project_id}/story
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/projects/{project_id}/story",
+    response_model=BlueprintStoryRead,
+    summary="Get blueprint story (Scope tab — phased narrative)",
+)
+async def get_blueprint_story(
+    project_id: str,
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> BlueprintStoryRead:
+    """Return the active phased story for a blueprint project.
+
+    The story is produced by Drew REASON (Wave 4).  Only the active version
+    (supersedes_id IS NULL) is returned; prior versions are ignored.
+
+    Law #9: markdown text is NOT logged or embedded in receipts — only
+    phase_count and mean_confidence are recorded.
+
+    Returns 404 when project is not visible to the requesting tenant (Law #6).
+    Emits blueprint.read.story receipt (Law #2).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    await _require_project(project_id, suite_id, scope, "blueprint.read.story")
+
+    try:
+        rows = await supabase_select(
+            "blueprint_stories",
+            filters=f"project_id=eq.{project_id}&suite_id=eq.{suite_id}&supersedes_id=is.null",
+            order_by="phase.asc",
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.get_story: DB error project=%s suite=%s error=%s",
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.read.story",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    # Build aggregated response from per-phase rows
+    phases: list[BlueprintStoryPhase] = []
+    mean_confidence: float | None = None
+    model_version: str | None = None
+    generated_at: datetime | None = None
+
+    for row in rows:
+        phase_num = row.get("phase")
+        markdown = row.get("markdown") or ""
+        if phase_num is not None:
+            phases.append(
+                BlueprintStoryPhase(
+                    phase_number=int(phase_num),
+                    markdown=markdown,
+                    truth_distribution=row.get("truth_distribution"),
+                )
+            )
+        # Harvest project-level metadata from any row
+        if mean_confidence is None and row.get("mean_confidence") is not None:
+            mean_confidence = float(row["mean_confidence"])
+        if model_version is None and row.get("model_version") is not None:
+            model_version = str(row["model_version"])
+        if generated_at is None:
+            raw_ts = row.get("created_at")
+            if isinstance(raw_ts, str):
+                try:
+                    generated_at = datetime.fromisoformat(raw_ts)
+                except ValueError:
+                    pass
+            elif isinstance(raw_ts, datetime):
+                generated_at = raw_ts
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.read.story",
+        outcome="success",
+        # Law #9: no markdown content in receipt
+        redacted_inputs={"project_id": project_id},
+        redacted_outputs={"phase_count": len(phases), "mean_confidence": mean_confidence},
+    )
+
+    return BlueprintStoryRead(
+        project_id=project_id,
+        phases=phases,
+        mean_confidence=mean_confidence,
+        model_version=model_version,
+        generated_at=generated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/blueprints/projects/{project_id}/missing_inputs/{input_id}/resolve
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/projects/{project_id}/missing_inputs/{input_id}/resolve",
+    summary="Resolve a missing input (YELLOW tier — capability token required)",
+    status_code=status.HTTP_200_OK,
+)
+async def resolve_missing_input(
+    project_id: str,
+    input_id: str,
+    body: MissingInputResolveRequest = Body(...),
+    x_tenant_id: str | None = Header(None, alias="x-tenant-id"),
+    x_suite_id: str | None = Header(None, alias="x-suite-id"),
+    x_office_id: str | None = Header(None, alias="x-office-id"),
+) -> dict[str, Any]:
+    """Resolve a contractor input gap.
+
+    YELLOW tier (Law #4): requires a valid capability_token in the request body.
+    Validates the token is non-empty (full server-side signature verification
+    delegated to the token_service in production — stub here for unit tests).
+
+    Actions:
+      1. Validates capability_token (fail-closed — Law #3).
+      2. Marks blueprint_missing_inputs row as resolved.
+      3. Inserts a field_confirmed blueprint_assemblies row derived from the gap.
+      4. Emits blueprint.missing_input.resolved receipt (Law #2).
+
+    Returns 404 when the project or input is not visible to the requesting
+    tenant (Law #6 — no existence leak).
+    """
+    scope = _resolve_scope(x_tenant_id, x_suite_id, x_office_id)
+    suite_id = str(scope.suite_id)
+
+    # Law #3 / Law #4: fail closed on missing or blank capability token
+    if not body.capability_token or not body.capability_token.strip():
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.missing_input.resolved",
+            risk_tier="yellow",
+            outcome="denied",
+            redacted_inputs={"project_id": project_id, "input_id": input_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"error": "MISSING_CAPABILITY_TOKEN"},
+        )
+
+    # Verify project ownership (Law #6)
+    await _require_project(project_id, suite_id, scope, "blueprint.missing_input.resolved")
+
+    # Load the missing input row
+    try:
+        input_rows = await supabase_select(
+            "blueprint_missing_inputs",
+            filters=f"id=eq.{input_id}&project_id=eq.{project_id}&suite_id=eq.{suite_id}",
+            limit=1,
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.resolve_input: DB error input=%s project=%s suite=%s error=%s",
+            input_id[:8] if len(input_id) >= 8 else input_id,
+            project_id[:8] if len(project_id) >= 8 else project_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.missing_input.resolved",
+            risk_tier="yellow",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id, "input_id": input_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    if not input_rows:
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.missing_input.resolved",
+            risk_tier="yellow",
+            outcome="not_found",
+            redacted_inputs={"project_id": project_id, "input_id": input_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Step 1: Mark missing input as resolved
+    try:
+        await supabase_update(
+            "blueprint_missing_inputs",
+            filters=f"id=eq.{input_id}&suite_id=eq.{suite_id}",
+            data={
+                "resolved_by": str(body.resolved_by),
+                "resolved_at": now_iso,
+            },
+        )
+    except SupabaseClientError as exc:
+        logger.error(
+            "blueprints.resolve_input: update failed input=%s suite=%s error=%s",
+            input_id[:8] if len(input_id) >= 8 else input_id,
+            suite_id[:8],
+            type(exc).__name__,
+        )
+        _cut_receipt(
+            scope=scope,
+            action_type="blueprint.missing_input.resolved",
+            risk_tier="yellow",
+            outcome="failed",
+            redacted_inputs={"project_id": project_id, "input_id": input_id},
+        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Update failed")
+
+    # Step 2: Insert a field_confirmed assembly row derived from the resolution
+    field_confirmed_id = str(uuid.uuid4())
+    assembly_row: dict[str, Any] = {
+        "id": field_confirmed_id,
+        "suite_id": suite_id,
+        "project_id": project_id,
+        "type": "field_confirmed_resolution",
+        "quantity": None,
+        "unit": None,
+        "truth": TruthClass.FIELD_CONFIRMED.value,
+        "supersedes_id": None,
+        "created_at": now_iso,
+        "created_by": str(body.resolved_by),
+    }
+
+    assembly_inserted = False
+    try:
+        from aspire_orchestrator.services.supabase_client import supabase_insert
+        await supabase_insert("blueprint_assemblies", assembly_row)
+        assembly_inserted = True
+    except (SupabaseClientError, Exception) as exc:
+        # Non-fatal: log and continue — primary action (resolve) succeeded
+        logger.warning(
+            "blueprints.resolve_input: assembly insert failed input=%s error=%s",
+            input_id[:8] if len(input_id) >= 8 else input_id,
+            type(exc).__name__,
+        )
+
+    _cut_receipt(
+        scope=scope,
+        action_type="blueprint.missing_input.resolved",
+        risk_tier="yellow",
+        outcome="success",
+        redacted_inputs={"project_id": project_id, "input_id": input_id},
+        redacted_outputs={
+            "resolved_at": now_iso,
+            "field_confirmed_assembly_id": field_confirmed_id,
+            "assembly_inserted": assembly_inserted,
+        },
+    )
+
+    return {
+        "success": True,
+        "input_id": input_id,
+        "resolved_at": now_iso,
+        "field_confirmed_assembly_id": field_confirmed_id,
+        "assembly_inserted": assembly_inserted,
+    }

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/__init__.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/__init__.py
@@ -2,6 +2,15 @@
 from __future__ import annotations
 
 from aspire_orchestrator.services.blueprint.schemas.assembly import BlueprintAssembly
+from aspire_orchestrator.services.blueprint.schemas.blueprint_assembly_read import (
+    BlueprintAssemblyRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_material_read import (
+    BlueprintMaterialRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_missing_input_read import (
+    BlueprintMissingInputRead,
+)
 from aspire_orchestrator.services.blueprint.schemas.blueprint_project import (
     BlueprintProject,
 )
@@ -14,11 +23,21 @@ from aspire_orchestrator.services.blueprint.schemas.blueprint_project_status imp
 from aspire_orchestrator.services.blueprint.schemas.blueprint_sheet_read import (
     BlueprintSheetRead,
 )
+from aspire_orchestrator.services.blueprint.schemas.blueprint_story_read import (
+    BlueprintStoryPhase,
+    BlueprintStoryRead,
+)
+from aspire_orchestrator.services.blueprint.schemas.blueprint_symbol_read import (
+    BlueprintSymbolRead,
+)
 from aspire_orchestrator.services.blueprint.schemas.material_line import (
     BlueprintMaterial,
 )
 from aspire_orchestrator.services.blueprint.schemas.missing_input import (
     BlueprintMissingInput,
+)
+from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+    MissingInputResolveRequest,
 )
 from aspire_orchestrator.services.blueprint.schemas.sheet import BlueprintSheet
 from aspire_orchestrator.services.blueprint.schemas.story import BlueprintStory
@@ -31,16 +50,23 @@ from aspire_orchestrator.services.blueprint.schemas.truth import (
 
 __all__ = [
     "BlueprintAssembly",
+    "BlueprintAssemblyRead",
     "BlueprintMaterial",
+    "BlueprintMaterialRead",
     "BlueprintMissingInput",
+    "BlueprintMissingInputRead",
     "BlueprintProject",
     "BlueprintProjectRead",
     "BlueprintProjectStatus",
     "BlueprintSheet",
     "BlueprintSheetRead",
     "BlueprintStory",
+    "BlueprintStoryPhase",
+    "BlueprintStoryRead",
     "BlueprintSymbol",
+    "BlueprintSymbolRead",
     "Discipline",
+    "MissingInputResolveRequest",
     "TariffFlag",
     "TruthClass",
 ]

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_assembly_read.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_assembly_read.py
@@ -1,0 +1,21 @@
+"""BlueprintAssemblyRead — read projection for the Scope tab."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from aspire_orchestrator.services.blueprint.schemas.truth import TruthClass
+
+
+class BlueprintAssemblyRead(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    id: UUID
+    type: str | None = None
+    quantity: float | None = None
+    unit: str | None = None
+    truth: TruthClass
+    supersedes_id: UUID | None = None
+    created_at: datetime

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_material_read.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_material_read.py
@@ -1,0 +1,27 @@
+"""BlueprintMaterialRead — read projection for the Scope tab (materials section).
+
+Law #9: supplier_id is an opaque UUID — not PII, safe to return.  The supplier
+address / business name must NOT appear here (they live in the supplier table).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from aspire_orchestrator.services.blueprint.schemas.truth import TariffFlag, TruthClass
+
+
+class BlueprintMaterialRead(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    id: UUID
+    line_item: str | None = None
+    quantity: float | None = None
+    unit: str | None = None
+    truth: TruthClass
+    tariff_flag: TariffFlag = TariffFlag.NONE
+    supplier_id: str | None = None
+    supersedes_id: UUID | None = None
+    created_at: datetime

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_missing_input_read.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_missing_input_read.py
@@ -1,0 +1,18 @@
+"""BlueprintMissingInputRead — read projection for the Scope tab (gaps section)."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintMissingInputRead(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    id: UUID
+    description: str | None = None
+    suggested_resolution: str | None = None
+    resolved_by: UUID | None = None
+    resolved_at: datetime | None = None
+    created_at: datetime

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_story_read.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_story_read.py
@@ -1,0 +1,38 @@
+"""BlueprintStoryRead — read projection for the Scope tab (story section).
+
+The story is the phased plain-English narrative produced by Wave 4 REASON.
+Only the active version (supersedes_id IS NULL) is returned.
+
+Law #9: markdown may contain contractor-facing descriptions.  The router
+returns the full markdown to the authenticated desktop client but must NEVER
+log or embed the markdown body inside receipts.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintStoryPhase(BaseModel):
+    """One phase within a blueprint story."""
+
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    phase_number: int
+    markdown: str
+    truth_distribution: dict[str, Any] | None = None
+
+
+class BlueprintStoryRead(BaseModel):
+    """Aggregated story read model returned to the desktop client."""
+
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    project_id: UUID
+    phases: list[BlueprintStoryPhase]
+    mean_confidence: float | None = None
+    model_version: str | None = None
+    generated_at: datetime | None = None

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_symbol_read.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/blueprint_symbol_read.py
@@ -1,0 +1,24 @@
+"""BlueprintSymbolRead — read projection for the Takeoff tab.
+
+Lighter than BlueprintSymbol (strips suite_id, office_id, created_by — all
+Internal implementation details not needed by the desktop client).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BlueprintSymbolRead(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    id: UUID
+    sheet_id: UUID
+    # DB column is `class`; Pydantic alias avoids the Python reserved word.
+    class_: str | None = None
+    bbox: dict[str, Any] | None = None
+    confidence: float | None = None
+    created_at: datetime

--- a/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/missing_input_resolve_request.py
+++ b/orchestrator/src/aspire_orchestrator/services/blueprint/schemas/missing_input_resolve_request.py
@@ -1,0 +1,28 @@
+"""MissingInputResolveRequest — body schema for POST .../resolve.
+
+This is a YELLOW-tier state-change action (Law #4).  The capability_token
+field is validated server-side by the route handler before any DB write.
+"""
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class MissingInputResolveRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=False)
+
+    resolution_value: str
+    resolved_by: UUID
+    # Capability token is passed as a raw string (JWT or signed blob);
+    # server-side verification happens in the route handler.
+    capability_token: str
+
+    @field_validator("resolution_value")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("resolution_value must not be blank")
+        return v

--- a/orchestrator/tests/test_drew_extended_read_apis.py
+++ b/orchestrator/tests/test_drew_extended_read_apis.py
@@ -1,0 +1,958 @@
+"""Drew Wave 2.7 — extended blueprint read API tests.
+
+Tests the six new endpoints added in Wave 2.7:
+  GET  /v1/blueprints/projects/{id}/symbols
+  GET  /v1/blueprints/projects/{id}/assemblies
+  GET  /v1/blueprints/projects/{id}/materials
+  GET  /v1/blueprints/projects/{id}/missing_inputs
+  GET  /v1/blueprints/projects/{id}/story
+  POST /v1/blueprints/projects/{id}/missing_inputs/{input_id}/resolve
+
+Law coverage:
+  Law #2 — every endpoint emits a receipt (success + failure + denial paths)
+  Law #3 — fail closed: missing headers → 401; missing token → 401
+  Law #4 — POST /resolve is YELLOW; capability_token required
+  Law #6 — cross-tenant returns 404 (no existence leak)
+  Law #9 — markdown body / supplier data never appear in receipt outputs
+
+Implementation note: route handler functions are tested directly (not via
+TestClient) because the full server.py requires `langgraph` which is not
+installed in the unit-test environment. This matches test_drew_read_apis.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+SUITE_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+SUITE_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+OFFICE_A = "aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+TENANT_A = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+PROJECT_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+SHEET_ID_1 = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+SHEET_ID_2 = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+INPUT_ID = "11111111-1111-1111-1111-111111111111"
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+_FAKE_PROJECT_ROW: dict[str, Any] = {
+    "id": PROJECT_ID,
+    "suite_id": SUITE_A,
+    "office_id": OFFICE_A,
+    "address": "abc123hash",
+    "created_at": _NOW,
+    "created_by": None,
+    "stage_progress": {
+        "ingest": "done",
+        "classify": "done",
+        "see": "done",
+        "reason": "done",
+        "procure": "not_started",
+    },
+}
+
+_FAKE_SHEET_ROWS: list[dict[str, Any]] = [
+    {"id": SHEET_ID_1, "suite_id": SUITE_A, "project_id": PROJECT_ID, "sheet_number": "A1", "created_at": _NOW},
+    {"id": SHEET_ID_2, "suite_id": SUITE_A, "project_id": PROJECT_ID, "sheet_number": "S1", "created_at": _NOW},
+]
+
+_FAKE_SYMBOL_ROWS: list[dict[str, Any]] = [
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "sheet_id": SHEET_ID_1,
+        "class_": "electrical_outlet",
+        "bbox": {"x": 10, "y": 20, "w": 5, "h": 5},
+        "confidence": 0.92,
+        "created_at": _NOW,
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "sheet_id": SHEET_ID_2,
+        "class_": "structural_beam",
+        "bbox": {"x": 50, "y": 60, "w": 10, "h": 3},
+        "confidence": 0.85,
+        "created_at": _NOW,
+    },
+]
+
+_FAKE_ASSEMBLY_ROWS: list[dict[str, Any]] = [
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "type": "concrete_pour",
+        "quantity": 45.0,
+        "unit": "cy",
+        "truth": "observed",
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "type": "drywall",
+        "quantity": 1200.0,
+        "unit": "sf",
+        "truth": "derived",
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+]
+
+_FAKE_ASSEMBLY_SUPERSEDED: dict[str, Any] = {
+    "id": str(uuid.uuid4()),
+    "suite_id": SUITE_A,
+    "project_id": PROJECT_ID,
+    "type": "old_framing",
+    "quantity": 800.0,
+    "unit": "lf",
+    "truth": "assumed",
+    "supersedes_id": str(uuid.uuid4()),  # non-null → superseded
+    "created_at": _NOW,
+}
+
+_FAKE_MATERIAL_ROWS: list[dict[str, Any]] = [
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "line_item": "structural_steel_beam",
+        "quantity": 12.0,
+        "unit": "ea",
+        "truth": "observed",
+        "tariff_flag": "section_232_steel",
+        "supplier_id": str(uuid.uuid4()),
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "line_item": "drywall_sheet_5_8",
+        "quantity": 240.0,
+        "unit": "sheet",
+        "truth": "derived",
+        "tariff_flag": "none",
+        "supplier_id": None,
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+]
+
+_FAKE_MISSING_INPUT_ROWS: list[dict[str, Any]] = [
+    {
+        "id": INPUT_ID,
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "description": "Wall length between columns A3-A4 unclear",
+        "suggested_resolution": "Measure on site and enter in feet",
+        "resolved_by": None,
+        "resolved_at": None,
+        "created_at": _NOW,
+    },
+]
+
+_FAKE_RESOLVED_INPUT_ROW: dict[str, Any] = {
+    "id": INPUT_ID,
+    "suite_id": SUITE_A,
+    "project_id": PROJECT_ID,
+    "description": "Wall length between columns A3-A4 unclear",
+    "suggested_resolution": "Measure on site and enter in feet",
+    "resolved_by": str(uuid.uuid4()),
+    "resolved_at": _NOW,
+    "created_at": _NOW,
+}
+
+_FAKE_STORY_ROWS: list[dict[str, Any]] = [
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "phase": 1,
+        "markdown": "## Phase 1: Site Preparation\n\nExcavation required for foundation.",
+        "truth_distribution": {"observed": 3, "derived": 1},
+        "mean_confidence": 0.88,
+        "model_version": "gpt-4o-2024-11-20",
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+    {
+        "id": str(uuid.uuid4()),
+        "suite_id": SUITE_A,
+        "project_id": PROJECT_ID,
+        "phase": 2,
+        "markdown": "## Phase 2: Framing\n\nSteel frame assembly begins after pour.",
+        "truth_distribution": {"observed": 5, "assumed": 2},
+        "mean_confidence": 0.88,
+        "model_version": "gpt-4o-2024-11-20",
+        "supersedes_id": None,
+        "created_at": _NOW,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clear_receipt_store():
+    from aspire_orchestrator.services.receipt_store import clear_store
+    clear_store()
+    yield
+    clear_store()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _query_receipts_by_action(action_type: str) -> list[dict]:
+    import aspire_orchestrator.services.receipt_store as rs
+    with rs._lock:
+        return [r for r in rs._receipts if r.get("action_type") == action_type]
+
+
+def _run(coro: Any) -> Any:
+    """Run a coroutine from synchronous test code."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ===========================================================================
+# Endpoint 1: list_blueprint_symbols
+# ===========================================================================
+
+class TestListBlueprintSymbols:
+    """GET /v1/blueprints/projects/{id}/symbols"""
+
+    def test_get_symbols_filters_by_sheet_id(self) -> None:
+        """sheet_id query param must restrict symbols to that sheet."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_symbols
+
+        sheet1_symbols = [s for s in _FAKE_SYMBOL_ROWS if s["sheet_id"] == SHEET_ID_1]
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            # First call: project existence check; second: symbols
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], sheet1_symbols]
+            result = _run(list_blueprint_symbols(
+                project_id=PROJECT_ID,
+                sheet_id=SHEET_ID_1,
+                confidence_floor=0.70,
+                class_prefix=None,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        sheet_ids = {str(s.sheet_id) for s in result}
+        assert sheet_ids == {SHEET_ID_1}, f"Expected only sheet {SHEET_ID_1}, got {sheet_ids}"
+
+    def test_get_symbols_returns_404_for_cross_tenant(self) -> None:
+        """Cross-tenant request must return 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_symbols
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],  # project not found for SUITE_B
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(list_blueprint_symbols(
+                    project_id=PROJECT_ID,
+                    sheet_id=None,
+                    confidence_floor=0.70,
+                    class_prefix=None,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+    def test_symbols_receipt_emitted_on_success(self) -> None:
+        """Successful symbols read must emit blueprint.read.symbols receipt (Law #2)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_symbols
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            sheet_ids_csv = f"{SHEET_ID_1},{SHEET_ID_2}"
+            mock_select.side_effect = [
+                [_FAKE_PROJECT_ROW],   # project check
+                _FAKE_SHEET_ROWS,      # sheet lookup (no sheet_id filter)
+                _FAKE_SYMBOL_ROWS,     # symbols
+            ]
+            _run(list_blueprint_symbols(
+                project_id=PROJECT_ID,
+                sheet_id=None,
+                confidence_floor=0.70,
+                class_prefix=None,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.read.symbols")
+        assert len(receipts) >= 1
+        r = receipts[-1]  # last receipt is the success one
+        assert r["outcome"] == "success"
+        assert r["risk_tier"] == "green"
+        # Law #9: receipt must not contain raw symbol data
+        receipt_str = json.dumps(r)
+        assert "electrical_outlet" not in receipt_str
+        assert "confidence" not in receipt_str or r["redacted_outputs"].get("symbol_count") is not None
+
+
+# ===========================================================================
+# Endpoint 2: list_blueprint_assemblies
+# ===========================================================================
+
+class TestListBlueprintAssemblies:
+    """GET /v1/blueprints/projects/{id}/assemblies"""
+
+    def test_get_assemblies_excludes_superseded_by_default(self) -> None:
+        """active_only=true (default) must add supersedes_id=is.null filter."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_assemblies
+
+        captured_filters: list[str] = []
+
+        async def _capture(table: str, filters: str | dict, **kwargs: Any) -> list[dict]:
+            if isinstance(filters, str):
+                captured_filters.append(filters)
+            if table == "blueprint_projects":
+                return [_FAKE_PROJECT_ROW]
+            return _FAKE_ASSEMBLY_ROWS
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            side_effect=_capture,
+        ):
+            _run(list_blueprint_assemblies(
+                project_id=PROJECT_ID,
+                active_only=True,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        all_filters = " ".join(captured_filters)
+        assert "supersedes_id=is.null" in all_filters, (
+            "active_only=true must send supersedes_id=is.null to PostgREST"
+        )
+
+    def test_assemblies_cross_tenant_returns_404(self) -> None:
+        """Cross-tenant assembly request returns 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_assemblies
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(list_blueprint_assemblies(
+                    project_id=PROJECT_ID,
+                    active_only=True,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+    def test_assemblies_receipt_emitted(self) -> None:
+        """Assembly read must emit blueprint.read.assemblies receipt (Law #2)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_assemblies
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], _FAKE_ASSEMBLY_ROWS]
+            _run(list_blueprint_assemblies(
+                project_id=PROJECT_ID,
+                active_only=True,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.read.assemblies")
+        assert len(receipts) >= 1
+        assert receipts[-1]["outcome"] == "success"
+
+
+# ===========================================================================
+# Endpoint 3: list_blueprint_materials
+# ===========================================================================
+
+class TestListBlueprintMaterials:
+    """GET /v1/blueprints/projects/{id}/materials"""
+
+    def test_get_materials_tariff_only_filter(self) -> None:
+        """tariff_only=true must add tariff_flag=neq.none filter."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_materials
+
+        captured_filters: list[str] = []
+
+        async def _capture(table: str, filters: str | dict, **kwargs: Any) -> list[dict]:
+            if isinstance(filters, str):
+                captured_filters.append(filters)
+            if table == "blueprint_projects":
+                return [_FAKE_PROJECT_ROW]
+            # Return only the tariff-flagged material
+            return [m for m in _FAKE_MATERIAL_ROWS if m["tariff_flag"] != "none"]
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            side_effect=_capture,
+        ):
+            result = _run(list_blueprint_materials(
+                project_id=PROJECT_ID,
+                tariff_only=True,
+                has_supplier=False,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        all_filters = " ".join(captured_filters)
+        assert "tariff_flag=neq.none" in all_filters, (
+            "tariff_only=true must send tariff_flag=neq.none filter to PostgREST"
+        )
+        tariff_flags = {str(m.tariff_flag) for m in result}
+        assert "none" not in tariff_flags, "No non-tariffed materials should appear with tariff_only=true"
+
+    def test_materials_no_pii_in_receipt(self) -> None:
+        """Receipts must not contain line_item text or supplier data (Law #9)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_materials
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], _FAKE_MATERIAL_ROWS]
+            _run(list_blueprint_materials(
+                project_id=PROJECT_ID,
+                tariff_only=False,
+                has_supplier=False,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.read.materials")
+        assert len(receipts) >= 1
+        for r in receipts:
+            receipt_str = json.dumps(r)
+            # Law #9: line item names and supplier data must not appear
+            assert "structural_steel_beam" not in receipt_str
+            assert "drywall_sheet" not in receipt_str
+            # supplier_id UUID values must not appear in receipt outputs
+            for mat in _FAKE_MATERIAL_ROWS:
+                if mat.get("supplier_id"):
+                    assert mat["supplier_id"] not in receipt_str
+
+    def test_materials_cross_tenant_returns_404(self) -> None:
+        """Cross-tenant materials request returns 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_materials
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(list_blueprint_materials(
+                    project_id=PROJECT_ID,
+                    tariff_only=False,
+                    has_supplier=False,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# Endpoint 4: list_blueprint_missing_inputs
+# ===========================================================================
+
+class TestListBlueprintMissingInputs:
+    """GET /v1/blueprints/projects/{id}/missing_inputs"""
+
+    def test_get_missing_inputs_unresolved_only_by_default(self) -> None:
+        """unresolved_only=true (default) must add resolved_at=is.null filter."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_missing_inputs
+
+        captured_filters: list[str] = []
+
+        async def _capture(table: str, filters: str | dict, **kwargs: Any) -> list[dict]:
+            if isinstance(filters, str):
+                captured_filters.append(filters)
+            if table == "blueprint_projects":
+                return [_FAKE_PROJECT_ROW]
+            return _FAKE_MISSING_INPUT_ROWS
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            side_effect=_capture,
+        ):
+            result = _run(list_blueprint_missing_inputs(
+                project_id=PROJECT_ID,
+                unresolved_only=True,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        all_filters = " ".join(captured_filters)
+        assert "resolved_at=is.null" in all_filters, (
+            "unresolved_only=true must send resolved_at=is.null to PostgREST"
+        )
+        # All returned rows must be unresolved
+        resolved = [r for r in result if r.resolved_at is not None]
+        assert not resolved, "No resolved inputs should appear with unresolved_only=true"
+
+    def test_missing_inputs_cross_tenant_returns_404(self) -> None:
+        """Cross-tenant missing inputs request returns 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_missing_inputs
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(list_blueprint_missing_inputs(
+                    project_id=PROJECT_ID,
+                    unresolved_only=True,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+    def test_missing_inputs_receipt_emitted(self) -> None:
+        """Missing inputs read must emit blueprint.read.missing_inputs receipt (Law #2)."""
+        from aspire_orchestrator.routes.blueprints import list_blueprint_missing_inputs
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], _FAKE_MISSING_INPUT_ROWS]
+            _run(list_blueprint_missing_inputs(
+                project_id=PROJECT_ID,
+                unresolved_only=True,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.read.missing_inputs")
+        assert len(receipts) >= 1
+        assert receipts[-1]["outcome"] == "success"
+
+
+# ===========================================================================
+# Endpoint 5: get_blueprint_story
+# ===========================================================================
+
+class TestGetBlueprintStory:
+    """GET /v1/blueprints/projects/{id}/story"""
+
+    def test_get_story_returns_phased_markdown(self) -> None:
+        """Story response must contain phases with markdown and phase_number."""
+        from aspire_orchestrator.routes.blueprints import get_blueprint_story
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], _FAKE_STORY_ROWS]
+            result = _run(get_blueprint_story(
+                project_id=PROJECT_ID,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        assert len(result.phases) == 2
+        assert result.phases[0].phase_number == 1
+        assert "Phase 1" in result.phases[0].markdown
+        assert result.phases[1].phase_number == 2
+
+    def test_story_no_markdown_in_receipt(self) -> None:
+        """Story receipt must not contain markdown content (Law #9)."""
+        from aspire_orchestrator.routes.blueprints import get_blueprint_story
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            mock_select.side_effect = [[_FAKE_PROJECT_ROW], _FAKE_STORY_ROWS]
+            _run(get_blueprint_story(
+                project_id=PROJECT_ID,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.read.story")
+        assert len(receipts) >= 1
+        r = receipts[-1]
+        receipt_str = json.dumps(r)
+        # Law #9: markdown text must never appear in receipt
+        assert "Site Preparation" not in receipt_str
+        assert "Excavation required" not in receipt_str
+        assert "Steel frame" not in receipt_str
+        # But count IS allowed
+        assert r["redacted_outputs"]["phase_count"] == 2
+
+    def test_story_cross_tenant_returns_404(self) -> None:
+        """Cross-tenant story request returns 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import get_blueprint_story
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(get_blueprint_story(
+                    project_id=PROJECT_ID,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# Endpoint 6: resolve_missing_input
+# ===========================================================================
+
+class TestResolveMissingInput:
+    """POST /v1/blueprints/projects/{id}/missing_inputs/{input_id}/resolve"""
+
+    def test_resolve_missing_input_updates_resolved_at(self) -> None:
+        """Successful resolve must update the missing input row's resolved_at."""
+        from aspire_orchestrator.routes.blueprints import resolve_missing_input
+        from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+            MissingInputResolveRequest,
+        )
+
+        body = MissingInputResolveRequest(
+            resolution_value="42 feet",
+            resolved_by=uuid.UUID(TENANT_A),
+            capability_token="valid-token-stub",
+        )
+
+        with (
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_select",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_update",
+                new_callable=AsyncMock,
+                return_value={},
+            ) as mock_update,
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_insert",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+        ):
+            mock_select.side_effect = [
+                [_FAKE_PROJECT_ROW],       # project existence check
+                _FAKE_MISSING_INPUT_ROWS,  # missing input load
+            ]
+            result = _run(resolve_missing_input(
+                project_id=PROJECT_ID,
+                input_id=INPUT_ID,
+                body=body,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        assert result["success"] is True
+        assert result["input_id"] == INPUT_ID
+        assert result["resolved_at"] is not None
+        # Verify supabase_update was called
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args
+        update_data = call_kwargs[0][2] if len(call_kwargs[0]) >= 3 else call_kwargs[1].get("data", {})
+        assert "resolved_at" in update_data
+        assert "resolved_by" in update_data
+
+    def test_resolve_missing_input_creates_field_confirmed_assembly(self) -> None:
+        """Resolve must insert a field_confirmed blueprint_assemblies row."""
+        from aspire_orchestrator.routes.blueprints import resolve_missing_input
+        from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+            MissingInputResolveRequest,
+        )
+
+        body = MissingInputResolveRequest(
+            resolution_value="42 feet",
+            resolved_by=uuid.UUID(TENANT_A),
+            capability_token="valid-token-stub",
+        )
+
+        inserted_tables: list[str] = []
+        inserted_data: list[dict] = []
+
+        async def _fake_insert(table: str, data: dict, **kwargs: Any) -> dict:
+            inserted_tables.append(table)
+            inserted_data.append(data)
+            return {}
+
+        with (
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_select",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_update",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_insert",
+                side_effect=_fake_insert,
+            ),
+        ):
+            mock_select.side_effect = [
+                [_FAKE_PROJECT_ROW],
+                _FAKE_MISSING_INPUT_ROWS,
+            ]
+            result = _run(resolve_missing_input(
+                project_id=PROJECT_ID,
+                input_id=INPUT_ID,
+                body=body,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        assert result["assembly_inserted"] is True
+        assert "blueprint_assemblies" in inserted_tables, (
+            "resolve must insert a row into blueprint_assemblies"
+        )
+        asm = inserted_data[0]
+        assert asm["truth"] == "field_confirmed"
+        assert asm["suite_id"] == SUITE_A
+        assert asm["project_id"] == PROJECT_ID
+
+    def test_resolve_missing_input_emits_yellow_receipt(self) -> None:
+        """Resolve must emit a YELLOW-tier blueprint.missing_input.resolved receipt (Law #2 + #4)."""
+        from aspire_orchestrator.routes.blueprints import resolve_missing_input
+        from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+            MissingInputResolveRequest,
+        )
+
+        body = MissingInputResolveRequest(
+            resolution_value="42 feet",
+            resolved_by=uuid.UUID(TENANT_A),
+            capability_token="valid-token-stub",
+        )
+
+        with (
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_select",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_update",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch(
+                "aspire_orchestrator.routes.blueprints.supabase_insert",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
+        ):
+            mock_select.side_effect = [
+                [_FAKE_PROJECT_ROW],
+                _FAKE_MISSING_INPUT_ROWS,
+            ]
+            _run(resolve_missing_input(
+                project_id=PROJECT_ID,
+                input_id=INPUT_ID,
+                body=body,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        receipts = _query_receipts_by_action("blueprint.missing_input.resolved")
+        success_receipts = [r for r in receipts if r["outcome"] == "success"]
+        assert len(success_receipts) >= 1, "Resolve must emit a success receipt (Law #2)"
+        r = success_receipts[-1]
+        assert r["risk_tier"] == "yellow", "Resolve receipt must be YELLOW tier (Law #4)"
+
+    def test_resolve_missing_input_denies_without_token(self) -> None:
+        """POST /resolve must deny with 401 when capability_token is blank (Law #3 / #4)."""
+        from aspire_orchestrator.routes.blueprints import resolve_missing_input
+        from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+            MissingInputResolveRequest,
+        )
+
+        body = MissingInputResolveRequest(
+            resolution_value="42 feet",
+            resolved_by=uuid.UUID(TENANT_A),
+            capability_token="   ",  # blank — must be rejected
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            _run(resolve_missing_input(
+                project_id=PROJECT_ID,
+                input_id=INPUT_ID,
+                body=body,
+                x_tenant_id=TENANT_A,
+                x_suite_id=SUITE_A,
+                x_office_id=OFFICE_A,
+            ))
+
+        assert exc_info.value.status_code == 401
+        # Denial must still emit a receipt (Law #2)
+        receipts = _query_receipts_by_action("blueprint.missing_input.resolved")
+        denied = [r for r in receipts if r["outcome"] == "denied"]
+        assert denied, "Denial must produce a receipt with outcome=denied"
+
+    def test_resolve_cross_tenant_returns_404(self) -> None:
+        """Cross-tenant resolve must return 404 (Law #6)."""
+        from aspire_orchestrator.routes.blueprints import resolve_missing_input
+        from aspire_orchestrator.services.blueprint.schemas.missing_input_resolve_request import (
+            MissingInputResolveRequest,
+        )
+
+        body = MissingInputResolveRequest(
+            resolution_value="42 feet",
+            resolved_by=uuid.UUID(TENANT_A),
+            capability_token="valid-token-stub",
+        )
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],  # project not found for SUITE_B
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(resolve_missing_input(
+                    project_id=PROJECT_ID,
+                    input_id=INPUT_ID,
+                    body=body,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                ))
+        assert exc_info.value.status_code == 404
+
+
+# ===========================================================================
+# Cross-cutting: receipt coverage + RLS (parametrized)
+# ===========================================================================
+
+class TestAllReadEndpointsEmitReceipt:
+    """Every read endpoint must emit at least one receipt per call (Law #2)."""
+
+    @pytest.mark.parametrize("action_type,handler_name,extra_kwargs", [
+        ("blueprint.read.symbols",       "list_blueprint_symbols",       {"sheet_id": SHEET_ID_1, "confidence_floor": 0.70, "class_prefix": None}),
+        ("blueprint.read.assemblies",    "list_blueprint_assemblies",    {"active_only": True}),
+        ("blueprint.read.materials",     "list_blueprint_materials",     {"tariff_only": False, "has_supplier": False}),
+        ("blueprint.read.missing_inputs","list_blueprint_missing_inputs",{"unresolved_only": True}),
+        ("blueprint.read.story",         "get_blueprint_story",          {}),
+    ])
+    def test_all_read_endpoints_emit_receipt(
+        self,
+        action_type: str,
+        handler_name: str,
+        extra_kwargs: dict,
+    ) -> None:
+        import aspire_orchestrator.routes.blueprints as bp
+        handler = getattr(bp, handler_name)
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+        ) as mock_select:
+            # First call: project check; subsequent calls: empty data (that's fine)
+            mock_select.side_effect = [
+                [_FAKE_PROJECT_ROW],
+                _FAKE_SHEET_ROWS,
+                _FAKE_SYMBOL_ROWS,
+                [],
+                [],
+            ]
+            try:
+                _run(handler(
+                    project_id=PROJECT_ID,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_A,
+                    x_office_id=OFFICE_A,
+                    **extra_kwargs,
+                ))
+            except (HTTPException, Exception):
+                pass  # Receipt must be emitted even on errors
+
+        receipts = _query_receipts_by_action(action_type)
+        assert len(receipts) >= 1, (
+            f"Endpoint {handler_name} did not emit a receipt for action_type={action_type}. "
+            "Every code path must emit a receipt (Law #2)."
+        )
+
+    @pytest.mark.parametrize("handler_name,extra_kwargs", [
+        ("list_blueprint_symbols",        {"sheet_id": None, "confidence_floor": 0.70, "class_prefix": None}),
+        ("list_blueprint_assemblies",     {"active_only": True}),
+        ("list_blueprint_materials",      {"tariff_only": False, "has_supplier": False}),
+        ("list_blueprint_missing_inputs", {"unresolved_only": True}),
+        ("get_blueprint_story",           {}),
+    ])
+    def test_all_read_endpoints_enforce_rls(
+        self,
+        handler_name: str,
+        extra_kwargs: dict,
+    ) -> None:
+        """All read endpoints must 404 for cross-tenant project_id (Law #6)."""
+        import aspire_orchestrator.routes.blueprints as bp
+        handler = getattr(bp, handler_name)
+
+        with patch(
+            "aspire_orchestrator.routes.blueprints.supabase_select",
+            new_callable=AsyncMock,
+            return_value=[],  # project not found for SUITE_B
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                _run(handler(
+                    project_id=PROJECT_ID,
+                    x_tenant_id=TENANT_A,
+                    x_suite_id=SUITE_B,
+                    x_office_id=OFFICE_A,
+                    **extra_kwargs,
+                ))
+
+        assert exc_info.value.status_code == 404, (
+            f"{handler_name}: cross-tenant request must return 404, got {exc_info.value.status_code}"
+        )


### PR DESCRIPTION
$(cat <<'EOF'
## Objective

Wave 2.7 — Extend the blueprint router with the remaining read endpoints needed by the Scope tab (Wave 7) and Takeoff tab (Wave 8), plus the YELLOW-tier resolve action for contractor field confirmations.

## Facts

- **Base:** `feat/wave-4-reason` (Wave 1 + 2 + 2.5 + 3 + 4 all merged)
- **Zero overlap** with `feat/wave-5-procure`: no changes to `drew_blueprint.py`, `tariff_engine.py`, `supplier_matcher.py`, `drew-tariff-rules.md`, or `test_drew_procure.py`
- **Extends** `routes/blueprints.py` (Wave 2.5 file); original 3 endpoints are unmodified
- **Adds** 6 new read schemas + 1 resolve request schema under `services/blueprint/schemas/`
- **Adds** 11 new tests in `tests/test_drew_extended_read_apis.py` following the exact pattern of `test_drew_read_apis.py`

## Changes

### New schemas (`services/blueprint/schemas/`)
| File | Model | Purpose |
|------|-------|---------|
| `blueprint_symbol_read.py` | `BlueprintSymbolRead` | Takeoff tab — symbol id, sheet_id, class_, bbox, confidence |
| `blueprint_assembly_read.py` | `BlueprintAssemblyRead` | Scope tab — assembly type, quantity, unit, truth |
| `blueprint_material_read.py` | `BlueprintMaterialRead` | Scope tab — line_item, tariff_flag, supplier_id (opaque UUID only) |
| `blueprint_missing_input_read.py` | `BlueprintMissingInputRead` | Scope tab — description, suggested_resolution, resolved_by/at |
| `blueprint_story_read.py` | `BlueprintStoryRead` + `BlueprintStoryPhase` | Scope tab — phased narrative with truth_distribution |
| `missing_input_resolve_request.py` | `MissingInputResolveRequest` | POST /resolve — resolution_value, resolved_by, capability_token |

`schemas/__init__.py` updated to export all 7 new symbols.

### New endpoints (`routes/blueprints.py`)
| Method | Path | Tier | Action type |
|--------|------|------|-------------|
| `GET` | `.../symbols` | GREEN | `blueprint.read.symbols` |
| `GET` | `.../assemblies` | GREEN | `blueprint.read.assemblies` |
| `GET` | `.../materials` | GREEN | `blueprint.read.materials` |
| `GET` | `.../missing_inputs` | GREEN | `blueprint.read.missing_inputs` |
| `GET` | `.../story` | GREEN | `blueprint.read.story` |
| `POST` | `.../missing_inputs/{id}/resolve` | **YELLOW** | `blueprint.missing_input.resolved` |

Also extracted `_require_project()` DRY helper (replaces copy-paste ownership check across all 5 GET endpoints).

### New test file (`tests/test_drew_extended_read_apis.py`)
11 tests covering:
- `test_get_symbols_filters_by_sheet_id`
- `test_get_symbols_returns_404_for_cross_tenant`
- `test_get_assemblies_excludes_superseded_by_default`
- `test_get_materials_tariff_only_filter`
- `test_get_missing_inputs_unresolved_only_by_default`
- `test_get_story_returns_phased_markdown`
- `test_resolve_missing_input_updates_resolved_at`
- `test_resolve_missing_input_creates_field_confirmed_assembly`
- `test_resolve_missing_input_emits_yellow_receipt`
- `test_all_read_endpoints_emit_receipt` (parametrized ×5)
- `test_all_read_endpoints_enforce_rls` (parametrized ×5)

## Verification

### pytest (mocked — no network)
```bash
cd backend/orchestrator
python -m pytest tests/test_drew_extended_read_apis.py -v
```

Expected: **11 passed** (+ parametrized variants = 21 total assertions)

### curl examples (against running server)

```bash
BASE=http://localhost:8000
SUITE=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
OFFICE=aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa
TENANT=cccccccc-cccc-cccc-cccc-cccccccccccc
PROJECT=dddddddd-dddd-dddd-dddd-dddddddddddd

# Symbols — confidence_floor + sheet filter
curl -s "$BASE/v1/blueprints/projects/$PROJECT/symbols?confidence_floor=0.80&sheet_id=$SHEET_ID" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" | jq .

# Assemblies — active only (default)
curl -s "$BASE/v1/blueprints/projects/$PROJECT/assemblies" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" | jq .

# Materials — tariff-flagged only
curl -s "$BASE/v1/blueprints/projects/$PROJECT/materials?tariff_only=true" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" | jq .

# Missing inputs — unresolved only (default)
curl -s "$BASE/v1/blueprints/projects/$PROJECT/missing_inputs" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" | jq .

# Story — active phases only
curl -s "$BASE/v1/blueprints/projects/$PROJECT/story" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" | jq .

# Resolve — YELLOW tier (requires capability_token)
curl -s -X POST "$BASE/v1/blueprints/projects/$PROJECT/missing_inputs/$INPUT_ID/resolve" \
  -H "x-suite-id: $SUITE" -H "x-office-id: $OFFICE" -H "x-tenant-id: $TENANT" \
  -H "Content-Type: application/json" \
  -d '{"resolution_value":"42 feet","resolved_by":"'$TENANT'","capability_token":"<minted-token>"}' | jq .
```

## Risks & Next Steps

- `supabase_insert` is imported lazily inside the resolve handler. If the function does not exist on `supabase_client`, the insert will fail gracefully (logged as warning; primary resolve still succeeds). Confirm `supabase_insert` exists in the client module before merge.
- `blueprint_stories` table name assumed (`blueprint_story` → plural `blueprint_stories`) — verify against migration 10x schema.
- Wave 5 (PROCURE) adds `supplier_id` to materials — `BlueprintMaterialRead` already includes `supplier_id: str | None` so no schema change needed when Wave 5 merges.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code) — `mcp-toolsmith` agent, Wave 2.7

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
EOF
)