### PR TITLE
feat(wave-5-1a): Unwrangle provider clients for Drew supplier discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,9 @@ ASPIRE_QUICKBOOKS_BASE_URL=
 ASPIRE_GUSTO_CLIENT_ID=
 ASPIRE_GUSTO_CLIENT_SECRET=
 
+# ─── Drew — Wave 5.1a (Supplier Discovery) ────────────────────────────────────────────
+ASPIRE_UNWRANGLE_API_KEY=
+
 # ─── Drew — Wave 1 (Blueprint Engine) ────────────────────────────────────────────
 ASPIRE_LLAMAPARSE_API_KEY=
 ASPIRE_AZURE_DOC_INTEL_ENDPOINT=

--- a/orchestrator/src/aspire_orchestrator/config/settings.py
+++ b/orchestrator/src/aspire_orchestrator/config/settings.py
@@ -121,6 +121,9 @@ class Settings(BaseSettings):
     parallel_extract_api_key: str = "" # ASPIRE_PARALLEL_EXTRACT_API_KEY — Parallel Extract (v1beta)
     apify_api_key: str = ""            # ASPIRE_APIFY_API_KEY — Apify Zillow scraper (property photos)
 
+    # --- Drew Blueprint Engine — Wave 5.1a Supplier Discovery ---
+    unwrangle_api_key: str = ""         # ASPIRE_UNWRANGLE_API_KEY — Unwrangle supplier catalog scraper
+
     # --- Drew Blueprint Engine provider keys (Wave 1) ---
     llamaparse_api_key: str = ""        # ASPIRE_LLAMAPARSE_API_KEY — LlamaParse PDF parser (primary)
     azure_doc_intel_endpoint: str = ""  # ASPIRE_AZURE_DOC_INTEL_ENDPOINT — Azure Doc Intel endpoint URL

--- a/orchestrator/src/aspire_orchestrator/providers/unwrangle_ferguson_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/unwrangle_ferguson_client.py
@@ -1,0 +1,343 @@
+﻿"""Unwrangle Ferguson Provider Client -- commercial plumbing/HVAC supplier discovery (Wave 5.1a).
+
+Provider: Unwrangle (https://data.unwrangle.com) -- Ferguson Home (build.com) engine
+Auth: Query parameter `api_key` -- no auth headers
+Risk tier: GREEN (read-only product search/detail)
+Idempotency: N/A (read-only)
+
+Verified working as of 2026-05-17:
+  - build_search: 590 results, real Ferguson catalog with inventory quantity
+  - build_detail: 17-variant Kohler sink with stock + dimensions + certifications
+
+Tools:
+  - unwrangle_ferguson.search_products: Search Ferguson Home via build_search
+  - unwrangle_ferguson.get_product_detail: Fetch full Ferguson product detail by URL
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aspire_orchestrator.config.settings import settings
+from aspire_orchestrator.models import Outcome
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderRequest,
+    ProviderResponse,
+)
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.tool_types import ToolExecutionResult
+
+logger = logging.getLogger(__name__)
+
+_UPSTREAM_DEGRADED = "UPSTREAM_DEGRADED"
+
+
+class UnwrangleFergusonClient(BaseProviderClient):
+    """Unwrangle Ferguson (build.com) product client."""
+
+    provider_id = "unwrangle_ferguson"
+    base_url = "https://data.unwrangle.com"
+    timeout_seconds = 12.0
+    max_retries = 1
+    idempotency_support = False
+
+    async def _authenticate_headers(
+        self, request: ProviderRequest
+    ) -> dict[str, str]:
+        return {}
+
+    def _parse_error(
+        self, status_code: int, body: dict[str, Any]
+    ) -> InternalErrorCode:
+        if status_code == 401:
+            return InternalErrorCode.AUTH_INVALID_KEY
+        if status_code == 402:
+            return InternalErrorCode.RATE_QUOTA_EXCEEDED
+        if status_code == 429:
+            return InternalErrorCode.RATE_LIMITED
+        if status_code == 504:
+            return InternalErrorCode.SERVER_BAD_GATEWAY
+        if 500 <= status_code < 600:
+            return InternalErrorCode.SERVER_UNAVAILABLE
+        return super()._parse_error(status_code, body)
+
+
+_client: UnwrangleFergusonClient | None = None
+
+
+def _get_client() -> UnwrangleFergusonClient:
+    global _client
+    if _client is None:
+        _client = UnwrangleFergusonClient()
+    return _client
+
+
+def _check_api_key(
+    client: UnwrangleFergusonClient,
+    tool_id: str,
+    correlation_id: str,
+    suite_id: str,
+    office_id: str,
+    risk_tier: str,
+    capability_token_id: str | None,
+    capability_token_hash: str | None,
+) -> tuple[str | None, ToolExecutionResult | None]:
+    api_key = settings.unwrangle_api_key
+    if not api_key:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.AUTH_INVALID_KEY.value,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return None, ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="Unwrangle API key not configured (ASPIRE_UNWRANGLE_API_KEY)",
+            receipt_data=receipt,
+        )
+    return api_key, None
+
+
+def _is_upstream_degraded(response: ProviderResponse) -> bool:
+    if response.status_code == 504:
+        return True
+    if (
+        response.status_code == 200
+        and not response.body.get("success", True)
+        and "unable to fetch" in str(response.body.get("error", "")).lower()
+    ):
+        return True
+    return False
+
+
+async def search_products(
+    line_item: str,
+    *,
+    suite_id: str,
+    office_id: str,
+    correlation_id: str,
+    page: int = 1,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Search Ferguson Home via Unwrangle build_search (commercial plumbing/HVAC)."""
+    client = _get_client()
+    tool_id = "unwrangle_ferguson.search_products"
+
+    api_key, deny = _check_api_key(
+        client, tool_id, correlation_id, suite_id, office_id,
+        risk_tier, capability_token_id, capability_token_hash,
+    )
+    if deny is not None:
+        return deny
+
+    if not line_item or not line_item.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Missing required parameter: line_item", receipt_data=receipt)
+
+    if len(line_item) > 500:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_INVALID_FORMAT.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="line_item exceeds 500 character limit", receipt_data=receipt)
+
+    query_safe = line_item[:100]
+    logger.info(
+        "unwrangle_ferguson.search_products: query=%r page=%d suite=%s corr=%s",
+        query_safe, page, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "build_search",
+        "search": line_item,
+        "page": str(page),
+        "api_key": api_key,  # type: ignore[arg-type]
+    }
+
+    request = ProviderRequest(
+        method="GET", path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=build_search "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "build_search", "query_normalized": query_safe, "page": page}
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Unwrangle build_search upstream scraper unavailable (504)", receipt_data=receipt)
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+        tool_id=tool_id, risk_tier=risk_tier, outcome=outcome, reason_code=reason,
+        capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {"platform": "build_search", "query_normalized": query_safe, "page": page}
+
+    if response.success:
+        raw_results = response.body.get("results", [])
+        result_count = len(raw_results)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_ferguson.search_products success: results=%d credits_remaining=%s suite=%s",
+            result_count, credits_remaining, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        receipt["redacted_outputs"] = {"result_count": result_count, "source_api": "build_search"}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS, tool_id=tool_id,
+            data={
+                "results": raw_results, "result_count": result_count,
+                "query": line_item, "page": page,
+                "source": "unwrangle_ferguson", "credits_remaining": credits_remaining,
+            },
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED, tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Ferguson error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )
+
+
+async def get_product_detail(
+    product_url: str,
+    *,
+    suite_id: str,
+    office_id: str,
+    correlation_id: str,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Fetch full Ferguson product detail by URL (Wave 5.1a drill-in)."""
+    client = _get_client()
+    tool_id = "unwrangle_ferguson.get_product_detail"
+
+    api_key, deny = _check_api_key(
+        client, tool_id, correlation_id, suite_id, office_id,
+        risk_tier, capability_token_id, capability_token_hash,
+    )
+    if deny is not None:
+        return deny
+
+    if not product_url or not product_url.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Missing required parameter: product_url", receipt_data=receipt)
+
+    url_safe = product_url[:100]
+    logger.info(
+        "unwrangle_ferguson.get_product_detail: url=%r suite=%s corr=%s",
+        url_safe, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "build_detail",
+        "url": product_url,
+        "api_key": api_key,  # type: ignore[arg-type]
+    }
+
+    request = ProviderRequest(
+        method="GET", path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=build_detail "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "build_detail", "url_normalized": url_safe}
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Unwrangle build_detail upstream scraper unavailable (504)", receipt_data=receipt)
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+        tool_id=tool_id, risk_tier=risk_tier, outcome=outcome, reason_code=reason,
+        capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {"platform": "build_detail", "url_normalized": url_safe}
+
+    if response.success:
+        product_data = response.body.get("product", response.body)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_ferguson.get_product_detail success: credits_remaining=%s suite=%s",
+            credits_remaining, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        receipt["redacted_outputs"] = {"has_product_data": bool(product_data), "source_api": "build_detail"}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS, tool_id=tool_id,
+            data={"product": product_data, "source": "unwrangle_ferguson", "credits_remaining": credits_remaining},
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED, tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Ferguson detail error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )

--- a/orchestrator/src/aspire_orchestrator/providers/unwrangle_homedepot_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/unwrangle_homedepot_client.py
@@ -1,0 +1,274 @@
+﻿"""Unwrangle Home Depot Provider Client -- supplier discovery for Drew (Wave 5.1a).
+
+Provider: Unwrangle (https://data.unwrangle.com)
+Auth: Query parameter `api_key` -- no auth headers
+Risk tier: GREEN (read-only product search)
+Idempotency: N/A (read-only)
+
+Verified working as of 2026-05-17:
+  - homedepot_search: 2569 PVC pipe results, full product data including bulk_pricing
+
+Known broken (Unwrangle-side 504 upstreams -- Wave 5.2 re-enable candidates):
+  - lowes_search, acehardware_search -> return 504 upstream scraper failure
+
+504 contract: Unwrangle returns HTTP 504 with {"success": false, "error": "..."}
+when their upstream scraper is down. This is NOT transient -- it means the scraper
+is unavailable. Do NOT retry (waste of credits). Return UPSTREAM_DEGRADED and let
+Adam router handle gracefully.
+
+Tools:
+  - unwrangle_homedepot.search_products: Search Home Depot via Unwrangle scraper
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aspire_orchestrator.config.settings import settings
+from aspire_orchestrator.models import Outcome
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderRequest,
+    ProviderResponse,
+)
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.tool_types import ToolExecutionResult
+
+logger = logging.getLogger(__name__)
+
+_UPSTREAM_DEGRADED = "UPSTREAM_DEGRADED"
+
+
+class UnwrangleHomeDepotClient(BaseProviderClient):
+    """Unwrangle Home Depot search client."""
+
+    provider_id = "unwrangle_homedepot"
+    base_url = "https://data.unwrangle.com"
+    timeout_seconds = 12.0
+    max_retries = 1
+    idempotency_support = False
+
+    async def _authenticate_headers(
+        self, request: ProviderRequest
+    ) -> dict[str, str]:
+        return {}
+
+    def _parse_error(
+        self, status_code: int, body: dict[str, Any]
+    ) -> InternalErrorCode:
+        if status_code == 401:
+            return InternalErrorCode.AUTH_INVALID_KEY
+        if status_code == 402:
+            return InternalErrorCode.RATE_QUOTA_EXCEEDED
+        if status_code == 429:
+            return InternalErrorCode.RATE_LIMITED
+        if status_code == 504:
+            return InternalErrorCode.SERVER_BAD_GATEWAY
+        if 500 <= status_code < 600:
+            return InternalErrorCode.SERVER_UNAVAILABLE
+        return super()._parse_error(status_code, body)
+
+
+_client: UnwrangleHomeDepotClient | None = None
+
+
+def _get_client() -> UnwrangleHomeDepotClient:
+    global _client
+    if _client is None:
+        _client = UnwrangleHomeDepotClient()
+    return _client
+
+
+def _is_upstream_degraded(response: ProviderResponse) -> bool:
+    if response.status_code == 504:
+        return True
+    if (
+        response.status_code == 200
+        and not response.body.get("success", True)
+        and "unable to fetch" in str(response.body.get("error", "")).lower()
+    ):
+        return True
+    return False
+
+
+async def search_products(
+    line_item: str,
+    *,
+    suite_id: str,
+    office_id: str,
+    office_zip: str | None,
+    correlation_id: str,
+    page: int = 1,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Search Home Depot via Unwrangle (failover for SerpAPI HD)."""
+    client = _get_client()
+    tool_id = "unwrangle_homedepot.search_products"
+
+    api_key = settings.unwrangle_api_key
+    if not api_key:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.AUTH_INVALID_KEY.value,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="Unwrangle API key not configured (ASPIRE_UNWRANGLE_API_KEY)",
+            receipt_data=receipt,
+        )
+
+    if not line_item or not line_item.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="Missing required parameter: line_item",
+            receipt_data=receipt,
+        )
+
+    if len(line_item) > 500:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_INVALID_FORMAT.value,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="line_item exceeds 500 character limit",
+            receipt_data=receipt,
+        )
+
+    query_safe = line_item[:100]
+    logger.info(
+        "unwrangle_homedepot.search_products: query=%r page=%d suite=%s corr=%s",
+        query_safe, page, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "homedepot_search",
+        "search": line_item,
+        "page": str(page),
+        "api_key": api_key,
+    }
+
+    request = ProviderRequest(
+        method="GET",
+        path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id,
+        suite_id=suite_id,
+        office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=homedepot_search "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "homedepot_search", "query_normalized": query_safe, "page": page}
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="Unwrangle homedepot_search upstream scraper unavailable (504)",
+            receipt_data=receipt,
+        )
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id,
+        suite_id=suite_id,
+        office_id=office_id,
+        tool_id=tool_id,
+        risk_tier=risk_tier,
+        outcome=outcome,
+        reason_code=reason,
+        capability_token_id=capability_token_id,
+        capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {
+        "platform": "homedepot_search",
+        "query_normalized": query_safe,
+        "page": page,
+        "office_zip": office_zip,
+    }
+
+    if response.success:
+        raw_results = response.body.get("results", [])
+        result_count = len(raw_results)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_homedepot success: results=%d credits_remaining=%s suite=%s",
+            result_count, credits_remaining, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        receipt["redacted_outputs"] = {"result_count": result_count, "source_api": "homedepot_search"}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS,
+            tool_id=tool_id,
+            data={
+                "results": raw_results,
+                "result_count": result_count,
+                "query": line_item,
+                "page": page,
+                "source": "unwrangle_homedepot",
+                "credits_remaining": credits_remaining,
+            },
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Home Depot error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )

--- a/orchestrator/src/aspire_orchestrator/providers/unwrangle_lowes_client.py
+++ b/orchestrator/src/aspire_orchestrator/providers/unwrangle_lowes_client.py
@@ -1,0 +1,467 @@
+﻿"""Unwrangle Lowes Provider Client -- local hardware/home improvement supplier discovery (Wave 5.1a).
+
+Provider: Unwrangle (https://data.unwrangle.com) -- Lowes engine
+Auth: Query parameter `api_key` -- no auth headers
+Risk tier: GREEN (read-only store/product data)
+Idempotency: N/A (read-only)
+
+Verified working as of 2026-05-17:
+  - lowes_store: 10 real GA stores returned for zip 30297
+  - lowes_category: 431 dishwasher results with store-localized inventory
+  - lowes_detail: Full Husqvarna spec sheet with variants
+
+Known broken (Unwrangle-side -- Wave 5.2 re-enable):
+  - lowes_search -> returns 504 upstream scraper failure (NOT wired here)
+
+PII policy: zipcode is not PII (safe to log). Store addresses NOT logged.
+
+Tools:
+  - unwrangle_lowes.find_nearest_store: Find up to 10 nearby Lowes stores by ZIP
+  - unwrangle_lowes.browse_category: Browse a Lowes category URL with store inventory
+  - unwrangle_lowes.get_product_detail: Fetch full Lowes product detail by URL
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aspire_orchestrator.config.settings import settings
+from aspire_orchestrator.models import Outcome
+from aspire_orchestrator.providers.base_client import (
+    BaseProviderClient,
+    ProviderRequest,
+    ProviderResponse,
+)
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+from aspire_orchestrator.services.tool_types import ToolExecutionResult
+
+logger = logging.getLogger(__name__)
+
+_UPSTREAM_DEGRADED = "UPSTREAM_DEGRADED"
+
+
+class UnwrangleLowesClient(BaseProviderClient):
+    """Unwrangle Lowes client (store finder + category browse + product detail)."""
+
+    provider_id = "unwrangle_lowes"
+    base_url = "https://data.unwrangle.com"
+    timeout_seconds = 12.0
+    max_retries = 1
+    idempotency_support = False
+
+    async def _authenticate_headers(
+        self, request: ProviderRequest
+    ) -> dict[str, str]:
+        return {}
+
+    def _parse_error(
+        self, status_code: int, body: dict[str, Any]
+    ) -> InternalErrorCode:
+        if status_code == 401:
+            return InternalErrorCode.AUTH_INVALID_KEY
+        if status_code == 402:
+            return InternalErrorCode.RATE_QUOTA_EXCEEDED
+        if status_code == 429:
+            return InternalErrorCode.RATE_LIMITED
+        if status_code == 504:
+            return InternalErrorCode.SERVER_BAD_GATEWAY
+        if 500 <= status_code < 600:
+            return InternalErrorCode.SERVER_UNAVAILABLE
+        return super()._parse_error(status_code, body)
+
+
+_client: UnwrangleLowesClient | None = None
+
+
+def _get_client() -> UnwrangleLowesClient:
+    global _client
+    if _client is None:
+        _client = UnwrangleLowesClient()
+    return _client
+
+
+def _check_api_key(
+    client: UnwrangleLowesClient,
+    tool_id: str,
+    correlation_id: str,
+    suite_id: str,
+    office_id: str,
+    risk_tier: str,
+    capability_token_id: str | None,
+    capability_token_hash: str | None,
+) -> tuple[str | None, ToolExecutionResult | None]:
+    api_key = settings.unwrangle_api_key
+    if not api_key:
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id,
+            suite_id=suite_id,
+            office_id=office_id,
+            tool_id=tool_id,
+            risk_tier=risk_tier,
+            outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.AUTH_INVALID_KEY.value,
+            capability_token_id=capability_token_id,
+            capability_token_hash=capability_token_hash,
+        )
+        return None, ToolExecutionResult(
+            outcome=Outcome.FAILED,
+            tool_id=tool_id,
+            error="Unwrangle API key not configured (ASPIRE_UNWRANGLE_API_KEY)",
+            receipt_data=receipt,
+        )
+    return api_key, None
+
+
+def _is_upstream_degraded(response: ProviderResponse) -> bool:
+    if response.status_code == 504:
+        return True
+    if (
+        response.status_code == 200
+        and not response.body.get("success", True)
+        and "unable to fetch" in str(response.body.get("error", "")).lower()
+    ):
+        return True
+    return False
+
+
+async def find_nearest_store(
+    *,
+    zipcode: str,
+    suite_id: str,
+    office_id: str,
+    correlation_id: str,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Returns up to 10 nearby Lowes stores. Used to get store_no for category browsing.
+
+    Verified 2026-05-17: 10 real GA stores for zip 30297.
+    PII: zipcode logged; store addresses NOT logged.
+    """
+    client = _get_client()
+    tool_id = "unwrangle_lowes.find_nearest_store"
+
+    api_key, deny = _check_api_key(
+        client, tool_id, correlation_id, suite_id, office_id,
+        risk_tier, capability_token_id, capability_token_hash,
+    )
+    if deny is not None:
+        return deny
+
+    if not zipcode or not zipcode.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Missing required parameter: zipcode", receipt_data=receipt)
+
+    logger.info(
+        "unwrangle_lowes.find_nearest_store: zipcode=%s suite=%s corr=%s",
+        zipcode, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "lowes_store",
+        "zipcode": zipcode,
+        "api_key": api_key,  # type: ignore[arg-type]
+    }
+
+    request = ProviderRequest(
+        method="GET", path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=lowes_store "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "lowes_store", "zipcode": zipcode}
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Unwrangle lowes_store upstream scraper unavailable (504)", receipt_data=receipt)
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+        tool_id=tool_id, risk_tier=risk_tier, outcome=outcome, reason_code=reason,
+        capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {"platform": "lowes_store", "zipcode": zipcode}
+
+    if response.success:
+        stores: list[dict[str, Any]] = (
+            response.body.get("stores")
+            or response.body.get("results")
+            or []
+        )
+        store_count = len(stores)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_lowes.find_nearest_store success: store_count=%d zipcode=%s suite=%s",
+            store_count, zipcode, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        # PII-safe: log count+zipcode, NOT store addresses
+        receipt["redacted_outputs"] = {"store_count": store_count, "source_api": "lowes_store", "zipcode": zipcode}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS, tool_id=tool_id,
+            data={
+                "stores": stores, "store_count": store_count,
+                "zipcode": zipcode, "source": "unwrangle_lowes",
+                "credits_remaining": credits_remaining,
+            },
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED, tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Lowes store error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )
+
+
+async def browse_category(
+    *,
+    category_url: str,
+    store_no: int,
+    suite_id: str,
+    office_id: str,
+    correlation_id: str,
+    page: int = 1,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Browse a Lowes category page with store-localized inventory.
+
+    Verified 2026-05-17: 431 dishwasher results with store-localized inventory.
+    store_no must come from find_nearest_store.
+    """
+    client = _get_client()
+    tool_id = "unwrangle_lowes.browse_category"
+
+    api_key, deny = _check_api_key(
+        client, tool_id, correlation_id, suite_id, office_id,
+        risk_tier, capability_token_id, capability_token_hash,
+    )
+    if deny is not None:
+        return deny
+
+    if not category_url or not category_url.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Missing required parameter: category_url", receipt_data=receipt)
+
+    url_safe = category_url[:100]
+    logger.info(
+        "unwrangle_lowes.browse_category: url=%r store_no=%d page=%d suite=%s corr=%s",
+        url_safe, store_no, page, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "lowes_category",
+        "url": category_url,
+        "store_no": str(store_no),
+        "page": str(page),
+        "api_key": api_key,  # type: ignore[arg-type]
+    }
+
+    request = ProviderRequest(
+        method="GET", path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=lowes_category "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "lowes_category", "url_normalized": url_safe, "store_no": store_no, "page": page}
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Unwrangle lowes_category upstream scraper unavailable (504)", receipt_data=receipt)
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+        tool_id=tool_id, risk_tier=risk_tier, outcome=outcome, reason_code=reason,
+        capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {"platform": "lowes_category", "url_normalized": url_safe, "store_no": store_no, "page": page}
+
+    if response.success:
+        raw_results = response.body.get("results", [])
+        result_count = len(raw_results)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_lowes.browse_category success: results=%d store_no=%d suite=%s",
+            result_count, store_no, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        receipt["redacted_outputs"] = {"result_count": result_count, "store_no": store_no, "source_api": "lowes_category"}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS, tool_id=tool_id,
+            data={
+                "results": raw_results, "result_count": result_count,
+                "category_url": category_url, "store_no": store_no,
+                "page": page, "source": "unwrangle_lowes",
+                "credits_remaining": credits_remaining,
+            },
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED, tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Lowes category error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )
+
+
+async def get_product_detail(
+    *,
+    product_url: str,
+    suite_id: str,
+    office_id: str,
+    correlation_id: str,
+    risk_tier: str = "green",
+    capability_token_id: str | None = None,
+    capability_token_hash: str | None = None,
+) -> ToolExecutionResult:
+    """Fetch full Lowes product detail by URL.
+
+    Verified 2026-05-17: full Husqvarna spec sheet with variants.
+    """
+    client = _get_client()
+    tool_id = "unwrangle_lowes.get_product_detail"
+
+    api_key, deny = _check_api_key(
+        client, tool_id, correlation_id, suite_id, office_id,
+        risk_tier, capability_token_id, capability_token_hash,
+    )
+    if deny is not None:
+        return deny
+
+    if not product_url or not product_url.strip():
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=InternalErrorCode.INPUT_MISSING_REQUIRED.value,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        )
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Missing required parameter: product_url", receipt_data=receipt)
+
+    url_safe = product_url[:100]
+    logger.info(
+        "unwrangle_lowes.get_product_detail: url=%r suite=%s corr=%s",
+        url_safe, suite_id[:8], correlation_id[:8],
+    )
+
+    query_params: dict[str, str] = {
+        "platform": "lowes_detail",
+        "url": product_url,
+        "api_key": api_key,  # type: ignore[arg-type]
+    }
+
+    request = ProviderRequest(
+        method="GET", path="/api/getter/",
+        query_params=query_params,
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+    )
+
+    response = await client._request(request)
+
+    if _is_upstream_degraded(response):
+        logger.warning(
+            "provider.unwrangle.degraded: endpoint=lowes_detail "
+            "reason=upstream_scraper_504 suite=%s corr=%s",
+            suite_id[:8], correlation_id[:8],
+        )
+        receipt = client.make_receipt_data(
+            correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+            tool_id=tool_id, risk_tier=risk_tier, outcome=Outcome.FAILED,
+            reason_code=_UPSTREAM_DEGRADED,
+            capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+            provider_response=response,
+        )
+        receipt["redacted_inputs"] = {"platform": "lowes_detail", "url_normalized": url_safe}
+        return ToolExecutionResult(outcome=Outcome.FAILED, tool_id=tool_id,
+            error="Unwrangle lowes_detail upstream scraper unavailable (504)", receipt_data=receipt)
+
+    outcome = Outcome.SUCCESS if response.success else Outcome.FAILED
+    reason = "EXECUTED" if response.success else (
+        response.error_code.value if response.error_code else "FAILED"
+    )
+    receipt = client.make_receipt_data(
+        correlation_id=correlation_id, suite_id=suite_id, office_id=office_id,
+        tool_id=tool_id, risk_tier=risk_tier, outcome=outcome, reason_code=reason,
+        capability_token_id=capability_token_id, capability_token_hash=capability_token_hash,
+        provider_response=response,
+    )
+    receipt["redacted_inputs"] = {"platform": "lowes_detail", "url_normalized": url_safe}
+
+    if response.success:
+        product_data = response.body.get("product", response.body)
+        credits_remaining = response.body.get("remaining_credits")
+        logger.info(
+            "unwrangle_lowes.get_product_detail success: credits_remaining=%s suite=%s",
+            credits_remaining, suite_id[:8],
+        )
+        if credits_remaining is not None:
+            receipt.setdefault("provider_metadata", {})
+            receipt["provider_metadata"]["credits_remaining"] = credits_remaining
+        receipt["redacted_outputs"] = {"has_product_data": bool(product_data), "source_api": "lowes_detail"}
+        return ToolExecutionResult(
+            outcome=Outcome.SUCCESS, tool_id=tool_id,
+            data={"product": product_data, "source": "unwrangle_lowes", "credits_remaining": credits_remaining},
+            receipt_data=receipt,
+        )
+    else:
+        return ToolExecutionResult(
+            outcome=Outcome.FAILED, tool_id=tool_id,
+            error=response.error_message or f"Unwrangle Lowes detail error: HTTP {response.status_code}",
+            receipt_data=receipt,
+        )

--- a/orchestrator/tests/providers/test_unwrangle_clients.py
+++ b/orchestrator/tests/providers/test_unwrangle_clients.py
@@ -1,0 +1,544 @@
+﻿"""Tests for Unwrangle provider clients -- Wave 5.1a supplier discovery."""
+
+from __future__ import annotations
+import json
+from typing import Any
+from unittest.mock import MagicMock
+import httpx
+import pytest
+from aspire_orchestrator.models import Outcome
+from aspire_orchestrator.providers.error_codes import InternalErrorCode
+
+SUITE_ID = "94b89098-c4bf-4419-a154-e18d9d53f993"
+OFFICE_ID = "94b89098-c4bf-4419-a154-e18d9d53f993"
+CORR_ID = "test-corr-unwrangle-001"
+FAKE_KEY = "fake-unwrangle-api-key-for-tests"
+
+def _make_http_response(status_code, body, url="https://data.unwrangle.com/api/getter/"):
+    req = httpx.Request("GET", url)
+    return httpx.Response(status_code, json=body, request=req)
+
+def _success_body(results=None):
+    return {"success": True, "results": results or [{"title": "PVC Pipe 1/2in", "price": 2.99}], "remaining_credits": 450}
+
+def _stores_body(stores=None):
+    return {"success": True, "stores": stores or [{"store_no": 501, "name": "Lowes Forest Park"}, {"store_no": 502, "name": "Lowes Morrow"}], "remaining_credits": 449}
+
+def _product_body():
+    return {"success": True, "product": {"title": "Kohler Archer Bathtub", "sku": "K-1123-LA", "variants": []}, "remaining_credits": 448}
+
+def _504_body():
+    return {"success": False, "error": "Unable to fetch search results from upstream"}
+
+def _401_body():
+    return {"success": False, "error": "Unauthorized - invalid api_key"}
+
+def _402_body():
+    return {"success": False, "error": "Payment Required - credits exhausted"}
+
+def _429_body():
+    return {"success": False, "error": "Rate limit exceeded"}
+
+def _500_body():
+    return {"success": False, "error": "Internal server error"}
+
+def _fake_get(status, body):
+    async def _g(self, url, **kw):
+        return _make_http_response(status, body)
+    return _g
+
+@pytest.fixture(autouse=True)
+def reset_clients():
+    import aspire_orchestrator.providers.unwrangle_homedepot_client as hd
+    import aspire_orchestrator.providers.unwrangle_ferguson_client as fg
+    import aspire_orchestrator.providers.unwrangle_lowes_client as lw
+    hd._client = None; fg._client = None; lw._client = None
+    yield
+    hd._client = None; fg._client = None; lw._client = None
+
+@pytest.fixture(autouse=True)
+def mock_receipt_logger(monkeypatch):
+    from aspire_orchestrator.services import provider_call_logger as pcl
+    s = MagicMock(); s.log_call = MagicMock(return_value=None)
+    monkeypatch.setattr(pcl, "_logger_instance", s)
+    monkeypatch.setattr(pcl, "get_provider_call_logger", lambda: s)
+
+@pytest.fixture()
+def with_api_key(monkeypatch):
+    import aspire_orchestrator.config.settings as sm
+    monkeypatch.setattr(sm.settings, "unwrangle_api_key", FAKE_KEY)
+
+@pytest.fixture()
+def without_api_key(monkeypatch):
+    import aspire_orchestrator.config.settings as sm
+    monkeypatch.setattr(sm.settings, "unwrangle_api_key", "")
+
+class TestUnwrangleHomeDepotSearchProducts:
+    @pytest.mark.asyncio
+    async def test_success_constructs_api_key_query_param(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("PVC pipe", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip="30297", correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert f"api_key={FAKE_KEY}" in captured[0]
+        assert "platform=homedepot_search" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_success_returns_results_and_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _success_body([{"title": "A", "price": 1}, {"title": "B", "price": 2}])))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("PVC pipe", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.receipt_data is not None
+        assert r.receipt_data.get("reason_code") == "EXECUTED"
+        assert r.data["result_count"] == 2
+        assert r.data["source"] == "unwrangle_homedepot"
+
+    @pytest.mark.asyncio
+    async def test_success_tracks_credits_remaining(self, monkeypatch, with_api_key):
+        b = _success_body(); b["remaining_credits"] = 123
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, b))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("drywall", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip="30297", correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.data["credits_remaining"] == 123
+        assert r.receipt_data.get("provider_metadata", {}).get("credits_remaining") == 123
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("lumber", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert len(calls) == 0
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.AUTH_INVALID_KEY.value
+        assert FAKE_KEY not in (r.error or "")
+
+    @pytest.mark.asyncio
+    async def test_missing_line_item_fails_with_receipt(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_MISSING_REQUIRED.value
+
+    @pytest.mark.asyncio
+    async def test_line_item_too_long_fails(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("x"*501, suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_INVALID_FORMAT.value
+
+    @pytest.mark.asyncio
+    async def test_504_soft_fail_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("drain snake", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+        assert "504" in (r.error or "")
+        assert FAKE_KEY not in (r.error or "")
+
+    @pytest.mark.asyncio
+    async def test_401_maps_auth_invalid_key(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(401, _401_body()))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("lumber", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data is not None
+        assert FAKE_KEY not in (r.error or "")
+
+    @pytest.mark.asyncio
+    async def test_402_credit_exhausted(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(402, _402_body()))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("drywall", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        pm = r.receipt_data.get("provider_metadata", {})
+        assert pm.get("error_code") == InternalErrorCode.RATE_QUOTA_EXCEEDED.value
+
+    @pytest.mark.asyncio
+    async def test_429_rate_limited(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(429, _429_body()))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("paint", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data is not None
+
+    @pytest.mark.asyncio
+    async def test_receipt_on_every_path(self, monkeypatch, with_api_key):
+        for sc, body in [(200, _success_body()), (504, _504_body()), (401, _401_body()), (500, _500_body())]:
+            def mk(s, b):
+                async def g(self, url, **kw): return _make_http_response(s, b)
+                return g
+            monkeypatch.setattr(httpx.AsyncClient, "get", mk(sc, body))
+            import aspire_orchestrator.providers.unwrangle_homedepot_client as hd
+            hd._client = None
+            from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+            r = await search_products("item", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+            assert r.receipt_data is not None, f"No receipt for HTTP {sc}"
+            assert "id" in r.receipt_data
+
+    @pytest.mark.asyncio
+    async def test_pii_safe_key_not_in_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _success_body()))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("copper wire", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip="30297", correlation_id=CORR_ID)
+        assert FAKE_KEY not in json.dumps(r.receipt_data)
+
+
+class TestUnwrangleFergusonSearchProducts:
+    @pytest.mark.asyncio
+    async def test_builds_correct_build_search_url(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("Kohler bathtub", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert "platform=build_search" in captured[0]
+        assert f"api_key={FAKE_KEY}" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_success_returns_results_and_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _success_body([{"title": "Kohler", "price": 649}])))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("Kohler bathtub", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.receipt_data is not None
+        assert r.data["source"] == "unwrangle_ferguson"
+
+    @pytest.mark.asyncio
+    async def test_504_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("copper pipe", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+        assert FAKE_KEY not in (r.error or "")
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("copper", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED and len(calls) == 0
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.AUTH_INVALID_KEY.value
+
+    @pytest.mark.asyncio
+    async def test_401_auth_invalid_key(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(401, _401_body()))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("copper", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert FAKE_KEY not in (r.error or "")
+        assert r.receipt_data is not None
+
+    @pytest.mark.asyncio
+    async def test_402_credit_exhausted(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(402, _402_body()))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("faucet", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        pm = r.receipt_data.get("provider_metadata", {})
+        assert pm.get("error_code") == InternalErrorCode.RATE_QUOTA_EXCEEDED.value
+
+
+class TestUnwrangleFergusonGetProductDetail:
+    @pytest.mark.asyncio
+    async def test_builds_correct_build_detail_url(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _product_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.build.com/product/detail/kohler-k-1123", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert "platform=build_detail" in captured[0]
+        assert f"api_key={FAKE_KEY}" in captured[0]
+        assert "url=" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_product_data_and_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _product_body()))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.build.com/product/detail/kohler-k-1123", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.data["product"] is not None
+        assert r.data["source"] == "unwrangle_ferguson"
+
+    @pytest.mark.asyncio
+    async def test_504_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.build.com/product/detail/kohler-k-1123", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+    @pytest.mark.asyncio
+    async def test_missing_product_url_fails(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import get_product_detail
+        r = await get_product_detail(product_url="", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_MISSING_REQUIRED.value
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _product_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.build.com/product/detail/kohler-k-1123", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED and len(calls) == 0
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.AUTH_INVALID_KEY.value
+
+
+class TestUnwrangleLowFindNearestStore:
+    @pytest.mark.asyncio
+    async def test_builds_correct_lowes_store_url(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _stores_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert "platform=lowes_store" in captured[0]
+        assert "zipcode=30297" in captured[0]
+        assert f"api_key={FAKE_KEY}" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_stores_with_store_no(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _stores_body([{"store_no": 501, "name": "Lowes FP"}, {"store_no": 502, "name": "Lowes M"}])))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.data["store_count"] == 2
+        assert r.data["stores"][0]["store_no"] == 501
+        assert r.receipt_data is not None
+
+    @pytest.mark.asyncio
+    async def test_504_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+        assert FAKE_KEY not in (r.error or "")
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _stores_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED and len(calls) == 0
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.AUTH_INVALID_KEY.value
+
+    @pytest.mark.asyncio
+    async def test_missing_zipcode_fails(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_MISSING_REQUIRED.value
+
+    @pytest.mark.asyncio
+    async def test_pii_safe_no_store_addresses_in_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _stores_body([{"store_no": 501, "address": "4800 Jonesboro Rd, Forest Park, GA 30297"}])))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        receipt_str = json.dumps(r.receipt_data)
+        assert "4800 Jonesboro Rd" not in receipt_str
+        assert FAKE_KEY not in receipt_str
+
+    @pytest.mark.asyncio
+    async def test_401_auth_invalid_key(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(401, _401_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        pm = r.receipt_data.get("provider_metadata", {})
+        assert pm.get("error_code") == InternalErrorCode.AUTH_INVALID_KEY.value
+
+    @pytest.mark.asyncio
+    async def test_402_credit_exhausted(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(402, _402_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import find_nearest_store
+        r = await find_nearest_store(zipcode="30297", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        pm = r.receipt_data.get("provider_metadata", {})
+        assert pm.get("error_code") == InternalErrorCode.RATE_QUOTA_EXCEEDED.value
+
+
+class TestUnwrangleLoweBrowseCategory:
+    @pytest.mark.asyncio
+    async def test_builds_correct_lowes_category_url(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="https://www.lowes.com/pl/Dishwashers", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert "platform=lowes_category" in captured[0]
+        assert "store_no=501" in captured[0]
+        assert f"api_key={FAKE_KEY}" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_results_and_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _success_body([{"title": "Bosch", "price": 799}])))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="https://www.lowes.com/pl/Dishwashers", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.data["result_count"] == 1
+        assert r.data["store_no"] == 501
+        assert r.data["source"] == "unwrangle_lowes"
+
+    @pytest.mark.asyncio
+    async def test_504_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="https://www.lowes.com/pl/Dishwashers", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _success_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="https://www.lowes.com/pl/Dishwashers", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED and len(calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_category_url_fails(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_MISSING_REQUIRED.value
+
+
+class TestUnwrangleLowesGetProductDetail:
+    @pytest.mark.asyncio
+    async def test_builds_correct_lowes_detail_url(self, monkeypatch, with_api_key):
+        captured = []
+        async def fg(self, url, **kw):
+            captured.append(url)
+            return _make_http_response(200, _product_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS, r.error
+        assert "platform=lowes_detail" in captured[0]
+        assert f"api_key={FAKE_KEY}" in captured[0]
+        assert "url=" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_product_data_and_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _product_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.SUCCESS
+        assert r.data["product"] is not None
+        assert r.data["source"] == "unwrangle_lowes"
+
+    @pytest.mark.asyncio
+    async def test_504_upstream_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(504, _504_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+    @pytest.mark.asyncio
+    async def test_fail_closed_missing_api_key(self, monkeypatch, without_api_key):
+        calls = []
+        async def fg(self, url, **kw):
+            calls.append(url)
+            return _make_http_response(200, _product_body())
+        monkeypatch.setattr(httpx.AsyncClient, "get", fg)
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED and len(calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_product_url_fails(self, monkeypatch, with_api_key):
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        assert r.receipt_data.get("reason_code") == InternalErrorCode.INPUT_MISSING_REQUIRED.value
+
+    @pytest.mark.asyncio
+    async def test_402_credit_exhausted(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(402, _402_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.outcome == Outcome.FAILED
+        pm = r.receipt_data.get("provider_metadata", {})
+        assert pm.get("error_code") == InternalErrorCode.RATE_QUOTA_EXCEEDED.value
+
+    @pytest.mark.asyncio
+    async def test_pii_safe_key_not_in_receipt(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, _product_body()))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import get_product_detail
+        r = await get_product_detail(product_url="https://www.lowes.com/pd/Husqvarna-450X/5013596041", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert FAKE_KEY not in json.dumps(r.receipt_data)
+
+
+class TestUnwrangleUpstreamDegradationBodyDetection:
+    @pytest.mark.asyncio
+    async def test_homedepot_200_success_false_is_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, {"success": False, "error": "Unable to fetch search results from the provider"}))
+        from aspire_orchestrator.providers.unwrangle_homedepot_client import search_products
+        r = await search_products("test", suite_id=SUITE_ID, office_id=OFFICE_ID, office_zip=None, correlation_id=CORR_ID)
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+    @pytest.mark.asyncio
+    async def test_ferguson_200_success_false_is_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, {"success": False, "error": "Unable to fetch search results from upstream scraper"}))
+        from aspire_orchestrator.providers.unwrangle_ferguson_client import search_products
+        r = await search_products("test", suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+    @pytest.mark.asyncio
+    async def test_lowes_category_200_success_false_is_degraded(self, monkeypatch, with_api_key):
+        monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get(200, {"success": False, "error": "Unable to fetch search results from Lowes"}))
+        from aspire_orchestrator.providers.unwrangle_lowes_client import browse_category
+        r = await browse_category(category_url="https://www.lowes.com/pl/Dishwashers", store_no=501, suite_id=SUITE_ID, office_id=OFFICE_ID, correlation_id=CORR_ID)
+        assert r.receipt_data.get("reason_code") == "UPSTREAM_DEGRADED"
+
+
+class TestUnwrangleSettingsField:
+    def test_unwrangle_api_key_field_exists(self, monkeypatch):
+        import aspire_orchestrator.config.settings as sm
+        monkeypatch.setattr(sm.settings, "unwrangle_api_key", "my-test-key")
+        assert sm.settings.unwrangle_api_key == "my-test-key"
+
+    def test_unwrangle_api_key_defaults_to_string(self):
+        import aspire_orchestrator.config.settings as sm
+        assert hasattr(sm.settings, "unwrangle_api_key")
+        assert isinstance(sm.settings.unwrangle_api_key, str)


### PR DESCRIPTION
## Objective

Wire 5 personally-verified Unwrangle endpoints as Aspire provider clients for Drew's Wave 5.1a supplier discovery. Three new provider client files + settings field extension + 48 tests.

## Facts (Verified 2026-05-17 with live API key)

| Endpoint | Result |
|----------|--------|
| `homedepot_search` | 2569 PVC pipe results, bulk_pricing included |
| `build_search` (Ferguson) | 590 results, real catalog with inventory_quantity |
| `build_detail` (Ferguson) | 17-variant Kohler sink, stock + dimensions + certifications |
| `lowes_store` | 10 real GA stores for zip 30297, store_no present |
| `lowes_category` | 431 dishwasher results with store-localized inventory |
| `lowes_detail` | Full Husqvarna spec sheet with variants |
| `lowes_search` | **504 BROKEN** (Unwrangle-side) — Wave 5.2 re-enable |
| `acehardware_search` | **504 BROKEN** (Unwrangle-side) — Wave 5.2 re-enable |

## Decision

- Auth via query param `api_key` (Unwrangle contract — no auth headers)
- 504 treated as `UPSTREAM_DEGRADED` soft-fail (not retried, not circuit-breaker-relevant) per no-fallback-design-principle carve-out for non-deterministic external scraper systems
- `remaining_credits` logged in receipt `provider_metadata` for ops monitoring
- `max_retries=1`, `timeout_seconds=12.0` per Unwrangle's scraper latency profile

## Changes

| File | Description |
|------|-------------|
| `orchestrator/src/aspire_orchestrator/config/settings.py` | Added `unwrangle_api_key: str = ""` (env: `ASPIRE_UNWRANGLE_API_KEY`) |
| `orchestrator/src/aspire_orchestrator/providers/unwrangle_homedepot_client.py` | `UnwrangleHomeDepotClient` + `search_products()` |
| `orchestrator/src/aspire_orchestrator/providers/unwrangle_ferguson_client.py` | `UnwrangleFergusonClient` + `search_products()` + `get_product_detail()` |
| `orchestrator/src/aspire_orchestrator/providers/unwrangle_lowes_client.py` | `UnwrangleLowesClient` + `find_nearest_store()` + `browse_category()` + `get_product_detail()` |
| `orchestrator/tests/providers/test_unwrangle_clients.py` | 48 tests covering all 3 clients |
| `.env.example` | Added `ASPIRE_UNWRANGLE_API_KEY=` entry |

Untouched (parallel agent territory): `adam_supplier_router.py`, `candidate_ranker.py`

## Verification

```
pytest tests/providers/test_unwrangle_clients.py -v
48 passed in 39.59s

pytest tests/providers/ -v
66 passed in 40.31s  # includes pre-existing tests, zero regressions
```

Test categories covered:
- URL construction: `api_key` as query param, correct `platform=` values
- Success: results list, receipt generation, `credits_remaining` in receipt metadata
- 504 soft-fail: `UPSTREAM_DEGRADED` reason_code, no retry, receipt emitted
- 200 + `success=false` scraper body: also maps to `UPSTREAM_DEGRADED`
- Fail-closed: missing `ASPIRE_UNWRANGLE_API_KEY` → deny before HTTP, no call made
- Input validation: empty/too-long `line_item`, empty `product_url`/`zipcode`
- Error mapping: 401→`AUTH_INVALID_KEY`, 402→`RATE_QUOTA_EXCEEDED`, 429→`RATE_LIMITED`, 5xx→`SERVER_UNAVAILABLE`
- PII-safe: `FAKE_KEY` never appears in `receipt_data` JSON; store addresses not in receipts
- Receipt coverage (Law #2): every code path produces `receipt_data` with `id` + `outcome`

## Risks and Next Steps

- `ASPIRE_UNWRANGLE_API_KEY` Railway env var must be set (parallel task #20)
- `lowes_search` and `acehardware_search` endpoints are **not wired** — Unwrangle upstream scraper returns 504. Re-enable in Wave 5.2 once Unwrangle confirms fix
- Parallel agent on `feat/wave-5-1a-adam-supplier-search` imports these clients via stub; ready to unblock once this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)