### PR TITLE
feat(memory): Wave 5.1b-1 — service visibility scope + service surfaces + property_thread

### DIFF
--- a/orchestrator/src/aspire_orchestrator/schemas/memory_v1.py
+++ b/orchestrator/src/aspire_orchestrator/schemas/memory_v1.py
@@ -97,6 +97,7 @@ SourceSurface = Literal[
     "nora_meeting",
     "finn_finance",
     "tim_service_lab",
+    # General Estimate Studio surface (non-service-hub context)
     "estimate_studio",
     "canvas_desk",
     "receipt_ledger",
@@ -106,6 +107,16 @@ SourceSurface = Literal[
     "tec_documents",    # Aspire upload pipeline (user-uploaded files)
     "google_calendar",  # Google Calendar push notifications
     "aspire_calendar",  # Aspire internal calendar events
+    # Wave 5.1b — Service Hub surfaces (service visibility scope)
+    # Service Hub Estimate Studio with Drew context (use for service visibility_scope writes)
+    "service_hub_estimate_studio",
+    "service_hub_jobs",
+    "service_hub_dispatch",
+    "service_hub_scheduling",
+    "service_hub_inspections",
+    "internal_drew",
+    "elevenlabs_tim_service",
+    "anam_tim_service",
 ]
 
 SourceAgent = Literal[
@@ -121,6 +132,8 @@ SourceAgent = Literal[
 VisibilityScope = Literal[
     "office",
     "finance",
+    "service",      # Wave 5.1b — Service Hub operational memory (Drew, jobs, dispatch).
+                    # NOTE: DB CHECK constraint update required in Wave 5.1b-2 migration before writing.
     "workflow",
     "admin",
     "restricted",
@@ -134,6 +147,7 @@ ThreadType = Literal[
     "deal_thread",
     "job_thread",
     "project_thread",
+    "property_thread",   # Wave 5.1b — all memory tied to a property address across projects/jobs
     "estimate_thread",
     "quote_thread",
     "invoice_thread",

--- a/orchestrator/tests/test_memory_service_scope.py
+++ b/orchestrator/tests/test_memory_service_scope.py
@@ -1,0 +1,151 @@
+"""Wave 5.1b-1 — verify service visibility scope, service surfaces, property_thread.
+
+Tests confirm:
+- VisibilityScope literal accepts "service" and rejects unknown values
+- 8 new Service Hub source surfaces validate
+- ThreadType accepts "property_thread"
+- Existing office/finance scopes still validate (regression check)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from aspire_orchestrator.schemas.memory_v1 import (
+    MemoryObjectIn,
+    Provenance,
+    ScopedIdentity,
+    ThreadIn,
+)
+
+
+TENANT = uuid.uuid4()
+SUITE = uuid.uuid4()
+OFFICE = uuid.uuid4()
+TRACE = uuid.uuid4()
+CORR = uuid.uuid4()
+
+
+def _scope() -> ScopedIdentity:
+    return ScopedIdentity(
+        tenant_id=TENANT,
+        suite_id=SUITE,
+        office_id=OFFICE,
+        actor_id=uuid.uuid4(),
+    )
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        trace_id=TRACE,
+        correlation_id=CORR,
+        source_surface="internal_drew",
+    )
+
+
+class TestVisibilityScopeService:
+    """VisibilityScope literal accepts 'service' and rejects bad values."""
+
+    def test_visibility_scope_accepts_service(self) -> None:
+        memory = MemoryObjectIn(
+            scope=_scope(),
+            provenance=_provenance(),
+            memory_type="decision_fact",
+            summary="Drew picked Ferguson for 1/2 PVC sched 40",
+            visibility_scope="service",
+        )
+        assert memory.visibility_scope == "service"
+
+    def test_visibility_scope_rejects_unknown(self) -> None:
+        with pytest.raises(ValidationError):
+            MemoryObjectIn(
+                scope=_scope(),
+                provenance=_provenance(),
+                memory_type="decision_fact",
+                summary="invalid scope",
+                visibility_scope="bogus",
+            )
+
+    def test_visibility_scope_rejects_none(self) -> None:
+        with pytest.raises(ValidationError):
+            MemoryObjectIn(
+                scope=_scope(),
+                provenance=_provenance(),
+                memory_type="decision_fact",
+                summary="none scope",
+                visibility_scope=None,
+            )
+
+    @pytest.mark.parametrize("scope_value", ["office", "finance"])
+    def test_office_and_finance_scopes_still_work(self, scope_value: str) -> None:
+        """Regression: existing scopes must keep validating."""
+        memory = MemoryObjectIn(
+            scope=_scope(),
+            provenance=_provenance(),
+            memory_type="decision_fact",
+            summary=f"regression check for {scope_value} scope",
+            visibility_scope=scope_value,
+        )
+        assert memory.visibility_scope == scope_value
+
+
+SERVICE_SURFACES = [
+    "service_hub_estimate_studio",
+    "service_hub_jobs",
+    "service_hub_dispatch",
+    "service_hub_scheduling",
+    "service_hub_inspections",
+    "internal_drew",
+    "elevenlabs_tim_service",
+    "anam_tim_service",
+]
+
+
+class TestSourceSurfaceServiceHub:
+    """8 new Service Hub source surfaces validate; unknown surface rejected."""
+
+    @pytest.mark.parametrize("surface", SERVICE_SURFACES)
+    def test_source_surface_accepts_service_hub_surfaces(self, surface: str) -> None:
+        prov = Provenance(
+            trace_id=TRACE,
+            correlation_id=CORR,
+            source_surface=surface,
+        )
+        assert prov.source_surface == surface
+
+    def test_source_surface_rejects_unknown(self) -> None:
+        with pytest.raises(ValidationError):
+            Provenance(
+                trace_id=TRACE,
+                correlation_id=CORR,
+                source_surface="drew_unknown_surface",
+            )
+
+
+class TestThreadTypePropertyThread:
+    """ThreadType accepts 'property_thread' (new) without breaking existing types."""
+
+    def test_thread_type_accepts_property_thread(self) -> None:
+        thread = ThreadIn(
+            tenant_id=TENANT,
+            suite_id=SUITE,
+            office_id=OFFICE,
+            thread_type="property_thread",
+        )
+        assert thread.thread_type == "property_thread"
+
+    @pytest.mark.parametrize("thread_type", ["project_thread", "job_thread"])
+    def test_thread_type_existing_service_threads_still_work(
+        self, thread_type: str
+    ) -> None:
+        """Regression: project_thread and job_thread were already present."""
+        thread = ThreadIn(
+            tenant_id=TENANT,
+            suite_id=SUITE,
+            office_id=OFFICE,
+            thread_type=thread_type,
+        )
+        assert thread.thread_type == thread_type


### PR DESCRIPTION
## Objective
Wave 5.1b-1 — extend Memory Service schema to support `"service"` visibility scope so Drew's `material_pick` writes can live in their own scope (separate from office/finance). Schema-only PR. Blocks Wave 5.1b-2 (migration), 5.1b-3 (routes), 5.1b-4 (brief_materializer).

## Facts (verified before changes)
- `VisibilityScope` Literal at `memory_v1.py:132-139` previously had `office | finance | workflow | admin | restricted`
- `SourceSurface` Literal at `memory_v1.py:93-119` had 14 values (no service surfaces)
- `ThreadType` Literal already includes `project_thread` and `job_thread`; only `property_thread` is new
- `memory_service.py` write path is scope-agnostic (verified — `visibility_scope` passes through as data, no branching)
- Pydantic v2 enforces Literal validation at construction time; backward-compatible additive change

## Decision
Surgical, additive Literal extension:
1. Add `"service"` to `VisibilityScope` between `"finance"` and `"workflow"`
2. Add 8 Service Hub source surfaces grouped with comment header
3. Add `"property_thread"` to `ThreadType` between `"project_thread"` and `"estimate_thread"`
4. Inline comment above `"service"` notes Wave 5.1b-2 DB CHECK constraint must land before service writes can persist (prevents premature production writes failing on DB constraint)
5. Disambiguation comment above existing `"estimate_studio"` to distinguish from new `"service_hub_estimate_studio"`

No runtime branching. No DB schema changes here (Wave 5.1b-2 owns the migration).

## Changes
| File | Type | Description |
|---|---|---|
| `schemas/memory_v1.py` | MODIFY | +12 lines: VisibilityScope + 8 SourceSurface entries + property_thread |
| `tests/test_memory_service_scope.py` | CREATE | 17 tests covering service scope, all 8 surfaces, property_thread, regression on office/finance + project/job threads |

## Verification
```
pytest orchestrator/tests/test_memory_service_scope.py -v
============================== 17 passed in 0.10s ==============================

pytest orchestrator/tests/test_memory_v1_schemas.py -v
============================= 160 passed in 0.19s =============================
```

Zero regression on the 160-test schema suite. Parametrized round-trip tests in `test_memory_v1_schemas.py` automatically cover the new Literal values via `get_args()`.

## Risks & Next Steps
- **R1 (mitigated):** DB `CHECK` constraint on `visibility_scope` will reject `"service"` writes until Wave 5.1b-2 migration lands. Mitigated by inline comment in code warning developers. No code in this PR writes to `visibility_scope="service"` yet (Drew writes go through Wave 5.1a-4 → office scope; migrate to service in Wave 5.1b-5).
- **R2 (low):** Naming collision risk between existing `"estimate_studio"` and new `"service_hub_estimate_studio"`. Mitigated by disambiguating comments inline.
- **Next:** Wave 5.1b-2 (migration to update DB CHECK constraint + create `service_brief_cache` table) unblocks immediately on this merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>