### PR TITLE
feat(memory): Wave 5.1b-4 — build_service_brief() with Law #2 receipt emission

### DIFF
--- a/orchestrator/src/aspire_orchestrator/schemas/memory_v1.py
+++ b/orchestrator/src/aspire_orchestrator/schemas/memory_v1.py
@@ -739,6 +739,40 @@ class FinanceBriefOut(BaseModel):
     freshness_seq: int = 0
 
 
+class ServiceBriefOut(BaseModel):
+    """Read-shape for service_brief_cache rows (Wave 5.1b-4).
+
+    Mirrors office_brief_cache layout (migration 101). Service-specific
+    summary counters are extracted from brief_json by BriefMaterializer on
+    every build so the cache table schema stays stable across feature passes.
+
+    Fields:
+      recent_picks_count      — last 5 material_pick decision_facts (Drew)
+      recent_overrides_count  — last 3 material_override decision_facts
+      open_pending_intents_count — unresolved service-scope pending_intents
+      recent_handoffs_count   — last 3 handoff_note entries (visibility=service)
+      active_threads_count    — project/job/property threads with recent activity
+    """
+
+    tenant_id: UUID
+    suite_id: UUID
+    office_id: UUID
+    brief_text: str | None = None
+    brief_json: dict = Field(default_factory=dict)
+    due_now_count: int = 0
+    overdue_count: int = 0
+    pending_approval_count: int = 0
+    recent_receipts_count: int = 0
+    # Service-specific summary counters (derived from brief_json on each build)
+    recent_picks_count: int = 0
+    recent_overrides_count: int = 0
+    open_pending_intents_count: int = 0
+    recent_handoffs_count: int = 0
+    active_threads_count: int = 0
+    last_built_at: datetime
+    freshness_seq: int = 0
+
+
 class ThreadBriefOut(BaseModel):
     """Read-shape for thread_brief_cache rows."""
 
@@ -801,6 +835,7 @@ __all__ = [
     "CandidateQuery",
     "OfficeBriefOut",
     "FinanceBriefOut",
+    "ServiceBriefOut",
     "ThreadBriefOut",
     # Pass 5 — memory search
     "MemorySearchRequest",

--- a/orchestrator/src/aspire_orchestrator/services/brief_materializer.py
+++ b/orchestrator/src/aspire_orchestrator/services/brief_materializer.py
@@ -1,8 +1,8 @@
-"""Brief Materializer — refresh office / finance / thread brief caches.
+"""Brief Materializer — refresh office / finance / service / thread brief caches.
 
 Each public method reads recent memory + open candidates + pending approvals
 + recent receipts, builds a JSON projection of the brief, and UPSERTs the
-result into the appropriate *_brief_cache table (migration 098). The
+result into the appropriate *_brief_cache table (migration 098 / 101). The
 freshness_seq column is monotonically incremented on every refresh so
 readers can detect concurrent rebuilds.
 
@@ -13,15 +13,20 @@ Refresh policy:
 Visibility scope (Law #6):
   - build_office_brief filters memory by visibility_scope='office'
   - build_finance_brief filters memory by visibility_scope='finance'
+  - build_service_brief filters memory by visibility_scope='service'
   - build_thread_brief reads only memory that already exists in the thread
     (visibility scope already enforced by the writer at memory_objects layer)
 
 Receipts (Law #2):
-  Brief refreshes do NOT emit receipts directly — the cache row is a
-  derivation of memory_objects + candidates + receipts that already each have
-  receipts. Re-emitting on every refresh would multiply receipt volume by
-  ~3x without adding audit value. The build itself is read-only against
-  source-of-truth tables.
+  - build_office_brief / build_finance_brief / build_thread_brief do NOT emit
+    receipts directly — the cache is a derivation of source-of-truth tables
+    that each already have receipts. Re-emitting on every refresh would
+    multiply receipt volume by ~3x without adding audit value.
+  - build_service_brief DOES emit a receipt (action=memory.service_brief.built)
+    because the service brief aggregates across multiple actor domains (drew,
+    adam, dispatch) and the Law #2 gap was identified in the office-memory
+    review notes. Service brief receipts close that audit gap for the
+    highest-traffic new domain.
 """
 
 from __future__ import annotations
@@ -31,10 +36,13 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
+import uuid
+
 from aspire_orchestrator.schemas.memory_v1 import (
     FinanceBriefOut,
     OfficeBriefOut,
     ScopedIdentity,
+    ServiceBriefOut,
     ThreadBriefOut,
 )
 from aspire_orchestrator.services.memory_service import (
@@ -101,6 +109,29 @@ def _finance_row_to_out(row: dict[str, Any]) -> FinanceBriefOut:
         provider_health=row.get("provider_health") or {},
         aging_summary=row.get("aging_summary") or {},
         cash_narrative=row.get("cash_narrative"),
+        last_built_at=_to_dt(row["last_built_at"]) or _now_utc(),
+        freshness_seq=int(row.get("freshness_seq", 0)),
+    )
+
+
+def _service_row_to_out(row: dict[str, Any]) -> ServiceBriefOut:
+    brief_json = row.get("brief_json") or {}
+    return ServiceBriefOut(
+        tenant_id=UUID(row["tenant_id"]),
+        suite_id=UUID(row["suite_id"]),
+        office_id=UUID(row["office_id"]),
+        brief_text=row.get("brief_text"),
+        brief_json=brief_json,
+        due_now_count=int(row.get("due_now_count", 0)),
+        overdue_count=int(row.get("overdue_count", 0)),
+        pending_approval_count=int(row.get("pending_approval_count", 0)),
+        recent_receipts_count=int(row.get("recent_receipts_count", 0)),
+        # Service-specific counters — populated from brief_json on build; 0 on cache replay
+        recent_picks_count=int(brief_json.get("recent_picks_count", 0)),
+        recent_overrides_count=int(brief_json.get("recent_overrides_count", 0)),
+        open_pending_intents_count=int(brief_json.get("open_pending_intents_count", 0)),
+        recent_handoffs_count=int(brief_json.get("recent_handoffs_count", 0)),
+        active_threads_count=int(brief_json.get("active_threads_count", 0)),
         last_built_at=_to_dt(row["last_built_at"]) or _now_utc(),
         freshness_seq=int(row.get("freshness_seq", 0)),
     )
@@ -310,6 +341,190 @@ class BriefMaterializer:
         return out
 
     # ---------------------------------------------------------------------------
+    # Service brief (Wave 5.1b-4)
+    # ---------------------------------------------------------------------------
+
+    async def build_service_brief(
+        self,
+        office_id: UUID,
+        *,
+        scope: ScopedIdentity,
+        refresh: bool = False,
+    ) -> ServiceBriefOut:
+        """Build/refresh service_brief_cache for the given office.
+
+        Reads recent service-scope memory_objects (picks, overrides, pending
+        intents, handoff notes) + service-domain open candidates + pending
+        approvals + recent receipts. UPSERTs into service_brief_cache.
+
+        Law #2: Emits memory.service_brief.built receipt on every build/refresh.
+        Law #6: All queries scoped by tenant_id + suite_id + office_id.
+        Law #9: Only counts and IDs are logged; no content or PII.
+
+        Args:
+            office_id: Must match scope.office_id (Law #6 — fail closed).
+            scope:     ScopedIdentity carrying tenant_id / suite_id / office_id.
+            refresh:   If True, bypass the 60s TTL and force a rebuild.
+
+        Returns:
+            ServiceBriefOut — the freshly built (or cached) brief.
+
+        Raises:
+            MemoryServiceError: office_id / scope mismatch or DB upsert failure.
+        """
+        if str(office_id) != str(scope.office_id):
+            raise MemoryServiceError(
+                f"office_id={office_id} does not match scope.office_id={scope.office_id}",
+                code="TENANT_ISOLATION_VIOLATION",
+                tenant_id=scope.tenant_id,
+            )
+
+        cached = await self._fetch_service_cache(scope)
+        if cached and not refresh and self._is_fresh(cached.last_built_at):
+            return cached
+
+        # ------------------------------------------------------------------ #
+        # Aggregate source data                                                #
+        # ------------------------------------------------------------------ #
+        recent_picks = await self._fetch_service_decision_facts(
+            scope=scope, decision_type="material_pick", limit=5
+        )
+        recent_overrides = await self._fetch_service_decision_facts(
+            scope=scope, decision_type="material_override", limit=3
+        )
+        open_pending_intents = await self._fetch_service_pending_intents(
+            scope=scope, limit=20
+        )
+        recent_handoffs = await self._fetch_service_handoffs(scope=scope, limit=3)
+        active_threads_count = await self._fetch_service_active_threads_count(scope=scope)
+        open_candidates = await self._fetch_open_candidates(scope=scope, limit=20)
+        pending_approvals = await self._fetch_pending_approvals(scope=scope, limit=20)
+        recent_receipts = await self._fetch_recent_receipts(scope=scope, limit=10)
+
+        now = _now_utc()
+        due_now_count = self._count_due_now(open_candidates, now=now)
+        overdue_count = self._count_overdue(open_candidates, now=now)
+
+        # ------------------------------------------------------------------ #
+        # Build brief_json — counts embedded for cache replay                 #
+        # ------------------------------------------------------------------ #
+        brief_json: dict[str, Any] = {
+            "recent_picks": [self._project_memory(m) for m in recent_picks],
+            "recent_overrides": [self._project_memory(m) for m in recent_overrides],
+            "open_pending_intents": [self._project_memory(m) for m in open_pending_intents],
+            "recent_handoffs": [self._project_memory(m) for m in recent_handoffs],
+            "open_candidates": [self._project_candidate(c) for c in open_candidates],
+            "pending_approvals": [self._project_approval(a) for a in pending_approvals],
+            "recent_receipts": [self._project_receipt(r) for r in recent_receipts],
+            # Embed counts into brief_json so _service_row_to_out() can recover
+            # them on cache replay without re-querying source tables.
+            "recent_picks_count": len(recent_picks),
+            "recent_overrides_count": len(recent_overrides),
+            "open_pending_intents_count": len(open_pending_intents),
+            "recent_handoffs_count": len(recent_handoffs),
+            "active_threads_count": active_threads_count,
+        }
+        brief_text = self._render_service_text(
+            recent_picks_count=len(recent_picks),
+            recent_overrides_count=len(recent_overrides),
+            open_pending_intents_count=len(open_pending_intents),
+            recent_handoffs_count=len(recent_handoffs),
+            active_threads_count=active_threads_count,
+            open_candidate_count=len(open_candidates),
+            pending_approval_count=len(pending_approvals),
+            due_now_count=due_now_count,
+            overdue_count=overdue_count,
+        )
+
+        next_seq = (cached.freshness_seq + 1) if cached else 1
+        upsert_row = {
+            "tenant_id": str(scope.tenant_id),
+            "suite_id": str(scope.suite_id),
+            "office_id": str(office_id),
+            "brief_text": brief_text,
+            "brief_json": brief_json,
+            "due_now_count": due_now_count,
+            "overdue_count": overdue_count,
+            "pending_approval_count": len(pending_approvals),
+            "recent_receipts_count": len(recent_receipts),
+            "last_built_at": now.isoformat(),
+            "freshness_seq": next_seq,
+        }
+
+        # ------------------------------------------------------------------ #
+        # Upsert                                                               #
+        # ------------------------------------------------------------------ #
+        correlation_id = str(uuid.uuid4())
+        success = False
+        try:
+            row = await supabase_upsert(
+                "service_brief_cache",
+                upsert_row,
+                on_conflict="tenant_id,suite_id,office_id",
+            )
+            success = True
+        except SupabaseClientError as exc:
+            raise MemoryServiceError(
+                f"DB upsert service_brief_cache failed: {exc.detail}",
+                code="DB_UPSERT_FAILED",
+                tenant_id=scope.tenant_id,
+            ) from exc
+        finally:
+            # ---------------------------------------------------------------- #
+            # Law #2 — emit receipt for every service brief build attempt       #
+            # (success OR failure). Counts only — no PII, no content (Law #9). #
+            # ---------------------------------------------------------------- #
+            receipt_outcome = "ok" if success else "failed"
+            try:
+                from aspire_orchestrator.services.receipt_store import store_receipts
+                store_receipts([{
+                    "id": str(uuid.uuid4()),
+                    "correlation_id": correlation_id,
+                    "receipt_type": "memory.service_brief.built",
+                    "action_type": "memory.service_brief.built",
+                    "actor": "system",
+                    "actor_type": "SYSTEM",
+                    "risk_tier": "GREEN",
+                    "suite_id": str(scope.suite_id),
+                    "tenant_id": str(scope.tenant_id),
+                    "office_id": str(office_id),
+                    "outcome": receipt_outcome,
+                    "details": {
+                        "picks_count": len(recent_picks),
+                        "overrides_count": len(recent_overrides),
+                        "open_pending_intents_count": len(open_pending_intents),
+                        "recent_handoffs_count": len(recent_handoffs),
+                        "active_threads_count": active_threads_count,
+                        "open_candidates_count": len(open_candidates),
+                        "pending_approvals_count": len(pending_approvals),
+                        "recent_receipts_count": len(recent_receipts),
+                        "freshness_seq": next_seq,
+                    },
+                }])
+            except Exception as receipt_exc:
+                # Never let receipt emission crash the pipeline (but do log it)
+                logger.warning(
+                    "brief_materializer: service brief receipt emit failed: %s",
+                    receipt_exc,
+                )
+
+        out = _service_row_to_out(row)
+        # Law #9: log counts only, never the brief content
+        logger.info(
+            "brief_materializer: service brief built tenant=%s office=%s seq=%d "
+            "picks=%d overrides=%d pending_intents=%d handoffs=%d threads=%d",
+            str(scope.tenant_id),
+            str(office_id),
+            out.freshness_seq,
+            len(recent_picks),
+            len(recent_overrides),
+            len(open_pending_intents),
+            len(recent_handoffs),
+            active_threads_count,
+        )
+        return out
+
+    # ---------------------------------------------------------------------------
     # Thread brief
     # ---------------------------------------------------------------------------
 
@@ -429,6 +644,20 @@ class BriefMaterializer:
         except SupabaseClientError:
             return None
         return _finance_row_to_out(rows[0]) if rows else None
+
+    async def _fetch_service_cache(
+        self, scope: ScopedIdentity
+    ) -> ServiceBriefOut | None:
+        filter_str = (
+            f"tenant_id=eq.{scope.tenant_id}"
+            f"&suite_id=eq.{scope.suite_id}"
+            f"&office_id=eq.{scope.office_id}"
+        )
+        try:
+            rows = await supabase_select("service_brief_cache", filter_str, limit=1)
+        except SupabaseClientError:
+            return None
+        return _service_row_to_out(rows[0]) if rows else None
 
     async def _fetch_thread_cache(
         self, thread_id: UUID, scope: ScopedIdentity
@@ -569,6 +798,148 @@ class BriefMaterializer:
         except Exception:
             pass
         return {}
+
+    async def _fetch_service_decision_facts(
+        self,
+        *,
+        scope: ScopedIdentity,
+        decision_type: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch recent decision_fact memory objects filtered by a detail.decision_type tag.
+
+        decision_type is stored inside the detail JSONB column:
+          { "decision_type": "material_pick" | "material_override", ... }
+
+        PostgREST JSONB path filter: detail->>'decision_type'=eq.{decision_type}
+        maps to the PostgREST operator `detail->>decision_type=eq.{value}`.
+        """
+        filter_str = (
+            f"tenant_id=eq.{scope.tenant_id}"
+            f"&suite_id=eq.{scope.suite_id}"
+            f"&office_id=eq.{scope.office_id}"
+            f"&visibility_scope=eq.service"
+            f"&memory_type=eq.decision_fact"
+            f"&status=not.in.(rejected,superseded)"
+        )
+        try:
+            rows = await supabase_select(
+                "memory_objects",
+                filter_str,
+                order_by="last_activity_at.desc",
+                limit=limit * 5,  # over-fetch then filter client-side (PostgREST JSONB filter workaround)
+            )
+        except SupabaseClientError as exc:
+            logger.warning(
+                "brief_materializer: decision_fact fetch failed type=%s scope=%s: %s",
+                decision_type,
+                scope.tenant_id,
+                exc.detail,
+            )
+            return []
+
+        # Client-side filter on detail.decision_type (avoids complex PostgREST encoding)
+        filtered = [
+            r for r in rows
+            if isinstance(r.get("detail"), dict)
+            and r["detail"].get("decision_type") == decision_type
+        ]
+        return filtered[:limit]
+
+    async def _fetch_service_pending_intents(
+        self,
+        *,
+        scope: ScopedIdentity,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch unresolved pending_intent memory objects in service scope."""
+        filter_str = (
+            f"tenant_id=eq.{scope.tenant_id}"
+            f"&suite_id=eq.{scope.suite_id}"
+            f"&office_id=eq.{scope.office_id}"
+            f"&visibility_scope=eq.service"
+            f"&memory_type=eq.pending_intent"
+            f"&status=not.in.(executed,rejected,superseded)"
+        )
+        try:
+            return await supabase_select(
+                "memory_objects",
+                filter_str,
+                order_by="last_activity_at.desc",
+                limit=limit,
+            )
+        except SupabaseClientError as exc:
+            logger.warning(
+                "brief_materializer: pending_intent fetch failed scope=%s: %s",
+                scope.tenant_id,
+                exc.detail,
+            )
+            return []
+
+    async def _fetch_service_handoffs(
+        self,
+        *,
+        scope: ScopedIdentity,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Fetch recent handoff_note memory objects with visibility_scope='service'."""
+        filter_str = (
+            f"tenant_id=eq.{scope.tenant_id}"
+            f"&suite_id=eq.{scope.suite_id}"
+            f"&office_id=eq.{scope.office_id}"
+            f"&visibility_scope=eq.service"
+            f"&memory_type=eq.handoff_note"
+            f"&status=not.in.(rejected,superseded)"
+        )
+        try:
+            return await supabase_select(
+                "memory_objects",
+                filter_str,
+                order_by="last_activity_at.desc",
+                limit=limit,
+            )
+        except SupabaseClientError as exc:
+            logger.warning(
+                "brief_materializer: handoff_note fetch failed scope=%s: %s",
+                scope.tenant_id,
+                exc.detail,
+            )
+            return []
+
+    async def _fetch_service_active_threads_count(
+        self,
+        *,
+        scope: ScopedIdentity,
+    ) -> int:
+        """Count open project_thread / job_thread / property_thread with recent activity.
+
+        'Recent' = last_activity_at within 7 days. Returns 0 on any error
+        (best-effort counter — the brief is still valid without this).
+        """
+        cutoff = (_now_utc() - timedelta(days=7)).isoformat()
+        filter_str = (
+            f"tenant_id=eq.{scope.tenant_id}"
+            f"&suite_id=eq.{scope.suite_id}"
+            f"&office_id=eq.{scope.office_id}"
+            f"&thread_type=in.(project_thread,job_thread,property_thread)"
+            f"&status=eq.open"
+            f"&last_activity_at=gte.{cutoff}"
+        )
+        try:
+            rows = await supabase_select(
+                "threads",
+                filter_str,
+                order_by="last_activity_at.desc",
+                limit=500,  # practical cap; real COUNT(*) would require RPC
+            )
+            return len(rows)
+        except SupabaseClientError as exc:
+            logger.warning(
+                "brief_materializer: active_threads count failed scope=%s: %s",
+                scope.tenant_id,
+                exc.detail,
+            )
+            return 0
 
     async def _fetch_thread_row(
         self,
@@ -802,6 +1173,30 @@ class BriefMaterializer:
     ) -> str:
         return (
             f"Finance brief: {recent_memory_count} finance-scoped memory items, "
+            f"{open_candidate_count} open candidates "
+            f"({due_now_count} due now, {overdue_count} overdue), "
+            f"{pending_approval_count} pending approvals."
+        )
+
+    @staticmethod
+    def _render_service_text(
+        *,
+        recent_picks_count: int,
+        recent_overrides_count: int,
+        open_pending_intents_count: int,
+        recent_handoffs_count: int,
+        active_threads_count: int,
+        open_candidate_count: int,
+        pending_approval_count: int,
+        due_now_count: int,
+        overdue_count: int,
+    ) -> str:
+        return (
+            f"Service brief: {recent_picks_count} recent picks, "
+            f"{recent_overrides_count} overrides, "
+            f"{open_pending_intents_count} open pending intents, "
+            f"{recent_handoffs_count} recent handoffs, "
+            f"{active_threads_count} active threads, "
             f"{open_candidate_count} open candidates "
             f"({due_now_count} due now, {overdue_count} overdue), "
             f"{pending_approval_count} pending approvals."

--- a/orchestrator/tests/test_build_service_brief.py
+++ b/orchestrator/tests/test_build_service_brief.py
@@ -1,0 +1,876 @@
+"""Tests for BriefMaterializer.build_service_brief().
+
+Coverage:
+  - Empty-state: no memory → empty brief, cache row upserted, receipt emitted
+  - With picks + overrides: brief_json contains projected items
+  - Pending intents: unresolved intents counted correctly
+  - Handoffs: handoff_note entries appear in brief
+  - Active threads: count reflects open service threads
+  - Refresh=False (cache hit): returns cached row, no re-upsert
+  - Refresh=True: bypasses TTL, rebuilds even when cache is fresh
+  - Stale cache: TTL expired → rebuilds
+  - Receipt emission: receipt with action=memory.service_brief.built present
+  - Receipt failure: receipt store error does NOT crash build
+  - RLS isolation (suite B sees nothing from suite A)
+  - office_id mismatch → MemoryServiceError with TENANT_ISOLATION_VIOLATION
+  - DB upsert failure → MemoryServiceError with DB_UPSERT_FAILED + failure receipt
+  - freshness_seq monotonically increases across rebuilds
+  - brief_text rendered from counts only (Law #9 — no content in rendered text)
+  - active_threads DB error → count defaults to 0, build continues
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from aspire_orchestrator.schemas.memory_v1 import (
+    ServiceBriefOut,
+    ScopedIdentity,
+)
+from aspire_orchestrator.services.brief_materializer import BriefMaterializer
+from aspire_orchestrator.services.memory_service import MemoryServiceError
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TENANT_A = uuid.uuid4()
+SUITE_A = uuid.uuid4()
+OFFICE_A = uuid.uuid4()
+
+TENANT_B = uuid.uuid4()
+SUITE_B = uuid.uuid4()
+OFFICE_B = uuid.uuid4()
+
+NOW = datetime.now(tz=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scope_a() -> ScopedIdentity:
+    return ScopedIdentity(tenant_id=TENANT_A, suite_id=SUITE_A, office_id=OFFICE_A)
+
+
+def _scope_b() -> ScopedIdentity:
+    return ScopedIdentity(tenant_id=TENANT_B, suite_id=SUITE_B, office_id=OFFICE_B)
+
+
+def _cache_row(
+    *,
+    scope: ScopedIdentity | None = None,
+    last_built: datetime | None = None,
+    freshness_seq: int = 1,
+    picks: int = 0,
+    overrides: int = 0,
+    pending_intents: int = 0,
+    handoffs: int = 0,
+    threads: int = 0,
+) -> dict[str, Any]:
+    """Build a service_brief_cache DB row dict."""
+    if scope is None:
+        scope = _scope_a()
+    if last_built is None:
+        last_built = NOW - timedelta(seconds=10)  # fresh
+    return {
+        "tenant_id": str(scope.tenant_id),
+        "suite_id": str(scope.suite_id),
+        "office_id": str(scope.office_id),
+        "brief_text": (
+            f"Service brief: {picks} recent picks, {overrides} overrides, "
+            f"{pending_intents} open pending intents, {handoffs} recent handoffs, "
+            f"{threads} active threads, 0 open candidates "
+            f"(0 due now, 0 overdue), 0 pending approvals."
+        ),
+        "brief_json": {
+            "recent_picks": [],
+            "recent_overrides": [],
+            "open_pending_intents": [],
+            "recent_handoffs": [],
+            "open_candidates": [],
+            "pending_approvals": [],
+            "recent_receipts": [],
+            "recent_picks_count": picks,
+            "recent_overrides_count": overrides,
+            "open_pending_intents_count": pending_intents,
+            "recent_handoffs_count": handoffs,
+            "active_threads_count": threads,
+        },
+        "due_now_count": 0,
+        "overdue_count": 0,
+        "pending_approval_count": 0,
+        "recent_receipts_count": 0,
+        "last_built_at": last_built.isoformat(),
+        "freshness_seq": freshness_seq,
+    }
+
+
+def _memory_row(
+    *,
+    memory_type: str = "decision_fact",
+    detail: dict[str, Any] | None = None,
+    scope: ScopedIdentity | None = None,
+    visibility_scope: str = "service",
+) -> dict[str, Any]:
+    """Build a minimal memory_objects row dict."""
+    if scope is None:
+        scope = _scope_a()
+    return {
+        "memory_id": str(uuid.uuid4()),
+        "tenant_id": str(scope.tenant_id),
+        "suite_id": str(scope.suite_id),
+        "office_id": str(scope.office_id),
+        "memory_type": memory_type,
+        "visibility_scope": visibility_scope,
+        "detail": detail or {},
+        "title": "test memory",
+        "summary": "test summary",
+        "status": "approved",
+        "thread_id": None,
+        "last_activity_at": NOW.isoformat(),
+    }
+
+
+def _pick_row(scope: ScopedIdentity | None = None) -> dict[str, Any]:
+    return _memory_row(
+        memory_type="decision_fact",
+        detail={"decision_type": "material_pick", "material": "tile"},
+        scope=scope,
+    )
+
+
+def _override_row(scope: ScopedIdentity | None = None) -> dict[str, Any]:
+    return _memory_row(
+        memory_type="decision_fact",
+        detail={"decision_type": "material_override", "material": "grout"},
+        scope=scope,
+    )
+
+
+def _pending_intent_row(scope: ScopedIdentity | None = None) -> dict[str, Any]:
+    return _memory_row(memory_type="pending_intent", scope=scope)
+
+
+def _handoff_row(scope: ScopedIdentity | None = None) -> dict[str, Any]:
+    return _memory_row(memory_type="handoff_note", scope=scope)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def materializer() -> BriefMaterializer:
+    return BriefMaterializer()
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty state — no memory → returns empty brief + upserts + emits receipt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestEmptyState:
+    async def test_empty_brief_upserts_cache_row(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """No memory objects → build succeeds, upsert called once."""
+        fresh_row = _cache_row(freshness_seq=1)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),  # cache miss + all data fetches empty
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=fresh_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        mock_upsert.assert_awaited_once()
+        assert isinstance(result, ServiceBriefOut)
+        assert result.tenant_id == TENANT_A
+        assert result.suite_id == SUITE_A
+        assert result.office_id == OFFICE_A
+        assert result.freshness_seq == 1
+
+    async def test_empty_brief_seq_starts_at_one(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """When no prior cache exists, freshness_seq initialises to 1."""
+        built_row = _cache_row(freshness_seq=1)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert result.freshness_seq == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. With picks + overrides — brief_json contains projected items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestWithServiceData:
+    async def test_three_picks_two_overrides(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """3 picks + 2 overrides → brief reflects those counts."""
+        picks = [_pick_row() for _ in range(3)]
+        # decision_fact rows for different types: picks + overrides returned together
+        overrides = [_override_row() for _ in range(2)]
+        all_decision_facts = picks + overrides
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []  # cache miss
+            if table == "memory_objects":
+                return all_decision_facts
+            return []
+
+        built_row = _cache_row(freshness_seq=1, picks=3, overrides=2)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        mock_upsert.assert_awaited_once()
+        upsert_payload = mock_upsert.call_args[0][1]  # second positional arg = row dict
+        assert upsert_payload["brief_json"]["recent_picks_count"] == 3
+        assert upsert_payload["brief_json"]["recent_overrides_count"] == 2
+        assert result.recent_picks_count == 3
+        assert result.recent_overrides_count == 2
+
+    async def test_pending_intents_counted(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """2 unresolved pending intents → open_pending_intents_count = 2."""
+        intents = [_pending_intent_row() for _ in range(2)]
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []
+            if table == "memory_objects":
+                return intents
+            return []
+
+        built_row = _cache_row(freshness_seq=1, pending_intents=2)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert result.open_pending_intents_count == 2
+
+    async def test_handoffs_counted(self, materializer: BriefMaterializer) -> None:
+        """3 handoff_note rows → recent_handoffs_count = 3."""
+        handoffs = [_handoff_row() for _ in range(3)]
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []
+            if table == "memory_objects":
+                return handoffs
+            return []
+
+        built_row = _cache_row(freshness_seq=1, handoffs=3)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert result.recent_handoffs_count == 3
+
+    async def test_active_threads_count_reflected(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """4 active threads → active_threads_count = 4."""
+        thread_rows = [
+            {
+                "tenant_id": str(TENANT_A),
+                "suite_id": str(SUITE_A),
+                "office_id": str(OFFICE_A),
+                "thread_id": str(uuid.uuid4()),
+                "thread_type": "job_thread",
+                "status": "open",
+                "last_activity_at": NOW.isoformat(),
+            }
+            for _ in range(4)
+        ]
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []
+            if table == "threads":
+                return thread_rows
+            return []  # memory_objects, proactive_candidates, approval_links, receipts
+
+        built_row = _cache_row(freshness_seq=1, threads=4)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert result.active_threads_count == 4
+
+
+# ---------------------------------------------------------------------------
+# 3. Cache TTL behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCacheBehaviour:
+    async def test_refresh_false_returns_fresh_cache(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Fresh cache (<60s) + refresh=False → return cache, NO upsert."""
+        fresh_row = _cache_row(last_built=NOW - timedelta(seconds=10), freshness_seq=5)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[fresh_row]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(),
+        ) as mock_upsert:
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        mock_upsert.assert_not_awaited()
+        assert result.freshness_seq == 5
+
+    async def test_refresh_true_bypasses_fresh_cache(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Fresh cache + refresh=True → still rebuilds."""
+        fresh_row = _cache_row(last_built=NOW - timedelta(seconds=10), freshness_seq=5)
+        rebuilt_row = _cache_row(last_built=NOW, freshness_seq=6)
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return [fresh_row]
+            return []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=rebuilt_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=True
+            )
+
+        mock_upsert.assert_awaited_once()
+        assert result.freshness_seq == 6
+
+    async def test_stale_cache_triggers_rebuild(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Stale cache (>60s) + refresh=False → rebuilds."""
+        stale_row = _cache_row(last_built=NOW - timedelta(minutes=5), freshness_seq=3)
+        rebuilt_row = _cache_row(last_built=NOW, freshness_seq=4)
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return [stale_row]
+            return []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=rebuilt_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        mock_upsert.assert_awaited_once()
+        assert result.freshness_seq == 4
+
+    async def test_freshness_seq_increments(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Two successive rebuilds → freshness_seq increases monotonically."""
+        stale_row = _cache_row(last_built=NOW - timedelta(minutes=5), freshness_seq=7)
+        rebuilt_row = _cache_row(last_built=NOW, freshness_seq=8)
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return [stale_row]
+            return []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=rebuilt_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=True
+            )
+
+        assert result.freshness_seq > stale_row["freshness_seq"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Receipt emission (Law #2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestReceiptEmission:
+    async def test_receipt_emitted_on_build(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Receipt with action=memory.service_brief.built is stored on every build."""
+        built_row = _cache_row(freshness_seq=1)
+        captured_receipts: list[dict] = []
+
+        def _capture(receipts: list[dict]) -> None:
+            captured_receipts.extend(receipts)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+            side_effect=_capture,
+        ):
+            await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert len(captured_receipts) == 1
+        r = captured_receipts[0]
+        assert r["action_type"] == "memory.service_brief.built"
+        assert r["outcome"] == "ok"
+        assert r["suite_id"] == str(SUITE_A)
+        assert r["tenant_id"] == str(TENANT_A)
+        assert r["office_id"] == str(OFFICE_A)
+
+    async def test_receipt_contains_counts_not_content(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Receipt details must contain integer counts, not memory content (Law #9)."""
+        built_row = _cache_row(freshness_seq=1)
+        captured_receipts: list[dict] = []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+            side_effect=lambda r: captured_receipts.extend(r),
+        ):
+            await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        details = captured_receipts[0]["details"]
+        for key in (
+            "picks_count",
+            "overrides_count",
+            "open_pending_intents_count",
+            "recent_handoffs_count",
+            "active_threads_count",
+        ):
+            assert key in details
+            assert isinstance(details[key], int), f"{key} should be int"
+
+    async def test_receipt_failure_does_not_crash_build(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """If receipt store raises, build_service_brief still returns successfully."""
+        built_row = _cache_row(freshness_seq=1)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+            side_effect=RuntimeError("receipt store unavailable"),
+        ):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        # Build must succeed even if receipt emission fails
+        assert isinstance(result, ServiceBriefOut)
+        assert result.freshness_seq == 1
+
+    async def test_receipt_emitted_on_failed_upsert(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Even when upsert raises, a failed receipt must be emitted (Law #2)."""
+        from aspire_orchestrator.services.supabase_client import SupabaseClientError
+
+        captured_receipts: list[dict] = []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(side_effect=SupabaseClientError("DB down", detail="DB down")),
+        ), patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+            side_effect=lambda r: captured_receipts.extend(r),
+        ):
+            with pytest.raises(MemoryServiceError):
+                await materializer.build_service_brief(
+                    OFFICE_A, scope=_scope_a(), refresh=False
+                )
+
+        # Receipt must still have been emitted with outcome=failed
+        assert len(captured_receipts) >= 1
+        assert captured_receipts[0]["outcome"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# 5. RLS isolation (Law #6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTenantIsolation:
+    async def test_suite_b_does_not_see_suite_a_picks(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """Suite B's fetch must use suite B's scope — never reads suite A data."""
+        suite_a_picks = [_pick_row(scope=_scope_a()) for _ in range(3)]
+        suite_b_row = _cache_row(scope=_scope_b(), freshness_seq=1)
+
+        # Capture filter strings used in supabase_select calls
+        observed_filters: list[str] = []
+
+        async def _select_spy(table: str, filter_str: str = "", **kwargs: Any) -> list[dict]:
+            observed_filters.append(filter_str)
+            if table == "service_brief_cache":
+                return []
+            return []  # suite B has no data
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_spy),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=suite_b_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_B, scope=_scope_b(), refresh=False
+            )
+
+        # Every filter that was issued must scope to SUITE_B, never SUITE_A
+        for f in observed_filters:
+            assert str(SUITE_A) not in f, (
+                f"Filter leaked suite A ID into suite B query: {f!r}"
+            )
+        assert result.suite_id == SUITE_B
+
+    async def test_office_id_scope_mismatch_raises(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """office_id that does not match scope.office_id → TENANT_ISOLATION_VIOLATION."""
+        mismatched_office = uuid.uuid4()
+
+        with pytest.raises(MemoryServiceError) as exc_info:
+            await materializer.build_service_brief(
+                mismatched_office, scope=_scope_a(), refresh=False
+            )
+
+        assert exc_info.value.code == "TENANT_ISOLATION_VIOLATION"
+
+    async def test_upsert_scoped_to_correct_tenant(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """The upsert payload must contain the correct tenant_id / suite_id."""
+        built_row = _cache_row(scope=_scope_b(), freshness_seq=1)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            await materializer.build_service_brief(
+                OFFICE_B, scope=_scope_b(), refresh=False
+            )
+
+        payload = mock_upsert.call_args[0][1]
+        assert payload["tenant_id"] == str(TENANT_B)
+        assert payload["suite_id"] == str(SUITE_B)
+        assert payload["office_id"] == str(OFFICE_B)
+
+
+# ---------------------------------------------------------------------------
+# 6. DB error handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestErrorHandling:
+    async def test_upsert_failure_raises_memory_service_error(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """SupabaseClientError on upsert → MemoryServiceError with DB_UPSERT_FAILED."""
+        from aspire_orchestrator.services.supabase_client import SupabaseClientError
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(side_effect=SupabaseClientError("DB down", detail="DB down")),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            with pytest.raises(MemoryServiceError) as exc_info:
+                await materializer.build_service_brief(
+                    OFFICE_A, scope=_scope_a(), refresh=False
+                )
+
+        assert exc_info.value.code == "DB_UPSERT_FAILED"
+
+    async def test_active_threads_db_error_defaults_to_zero(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """If threads table query fails, active_threads_count defaults to 0."""
+        from aspire_orchestrator.services.supabase_client import SupabaseClientError
+
+        built_row = _cache_row(freshness_seq=1, threads=0)
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []
+            if table == "threads":
+                raise SupabaseClientError("threads unavailable", detail="threads unavailable")
+            return []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        # build must succeed; threads count must degrade gracefully
+        assert isinstance(result, ServiceBriefOut)
+        assert result.active_threads_count == 0
+
+    async def test_memory_fetch_error_returns_empty_list(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """If memory_objects query fails, service helpers return [] (graceful degrade)."""
+        from aspire_orchestrator.services.supabase_client import SupabaseClientError
+
+        built_row = _cache_row(freshness_seq=1)
+
+        def _select_side_effect(table: str, *args: Any, **kwargs: Any) -> list[dict]:
+            if table == "service_brief_cache":
+                return []
+            if table == "memory_objects":
+                raise SupabaseClientError("memory unavailable", detail="memory unavailable")
+            return []
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(side_effect=_select_side_effect),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert isinstance(result, ServiceBriefOut)
+        # Counts must gracefully default to 0 on fetch failure
+        assert result.recent_picks_count == 0
+        assert result.recent_overrides_count == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Concurrency — duplicate upserts use ON CONFLICT key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestConcurrency:
+    async def test_on_conflict_key_in_upsert_call(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """supabase_upsert must be called with on_conflict=tenant_id,suite_id,office_id."""
+        built_row = _cache_row(freshness_seq=1)
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ) as mock_upsert, patch(
+            "aspire_orchestrator.services.receipt_store.store_receipts",
+        ):
+            await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        _, kwargs = mock_upsert.call_args
+        assert kwargs.get("on_conflict") == "tenant_id,suite_id,office_id"
+
+
+# ---------------------------------------------------------------------------
+# 8. Brief text (Law #9 — counts only, no content)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBriefText:
+    async def test_brief_text_contains_counts_only(
+        self, materializer: BriefMaterializer
+    ) -> None:
+        """brief_text must be a deterministic count-only string (no memory summaries)."""
+        built_row = _cache_row(freshness_seq=1, picks=2, overrides=1)
+        built_row["brief_text"] = (
+            "Service brief: 2 recent picks, 1 overrides, "
+            "0 open pending intents, 0 recent handoffs, "
+            "0 active threads, 0 open candidates "
+            "(0 due now, 0 overdue), 0 pending approvals."
+        )
+
+        with patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_select",
+            new=AsyncMock(return_value=[]),
+        ), patch(
+            "aspire_orchestrator.services.brief_materializer.supabase_upsert",
+            new=AsyncMock(return_value=built_row),
+        ), patch("aspire_orchestrator.services.receipt_store.store_receipts"):
+            result = await materializer.build_service_brief(
+                OFFICE_A, scope=_scope_a(), refresh=False
+            )
+
+        assert result.brief_text is not None
+        # Verify the rendered text is count-based
+        assert "Service brief:" in result.brief_text
+        assert "picks" in result.brief_text
+        assert "overrides" in result.brief_text
+
+
+# ---------------------------------------------------------------------------
+# 9. Schema — ServiceBriefOut Pydantic model
+# ---------------------------------------------------------------------------
+
+
+class TestServiceBriefOutSchema:
+    def test_defaults_are_zero(self) -> None:
+        """All integer counters default to zero."""
+        out = ServiceBriefOut(
+            tenant_id=TENANT_A,
+            suite_id=SUITE_A,
+            office_id=OFFICE_A,
+            last_built_at=NOW,
+        )
+        assert out.due_now_count == 0
+        assert out.overdue_count == 0
+        assert out.pending_approval_count == 0
+        assert out.recent_receipts_count == 0
+        assert out.recent_picks_count == 0
+        assert out.recent_overrides_count == 0
+        assert out.open_pending_intents_count == 0
+        assert out.recent_handoffs_count == 0
+        assert out.active_threads_count == 0
+        assert out.freshness_seq == 0
+
+    def test_counts_populated(self) -> None:
+        """ServiceBriefOut correctly holds service-specific counter fields."""
+        out = ServiceBriefOut(
+            tenant_id=TENANT_A,
+            suite_id=SUITE_A,
+            office_id=OFFICE_A,
+            last_built_at=NOW,
+            recent_picks_count=5,
+            recent_overrides_count=3,
+            open_pending_intents_count=7,
+            recent_handoffs_count=2,
+            active_threads_count=10,
+        )
+        assert out.recent_picks_count == 5
+        assert out.recent_overrides_count == 3
+        assert out.open_pending_intents_count == 7
+        assert out.recent_handoffs_count == 2
+        assert out.active_threads_count == 10


### PR DESCRIPTION
$(cat <<'EOF'
## Objective

Add `BriefMaterializer.build_service_brief()` — the fourth pass of Wave 5.1b — mirroring `build_office_brief()` and `build_finance_brief()` for the Service Hub operational memory domain (`visibility_scope=service`). Wired to the materializer cron sweep and the parallel `/v1/service-memory/get-memory-brief` route (companion PR on `feat/wave-5-1b-service-memory-routes`).

## Facts Verified

- `service_brief_cache` table created in migration 101 (`infrastructure/supabase/migrations/101_service_brief_cache.sql`): mirrors `office_brief_cache` shape exactly — `tenant_id/suite_id/office_id` composite PK, `brief_json JSONB`, `due_now_count/overdue_count/pending_approval_count/recent_receipts_count`, `last_built_at`, `freshness_seq BIGINT`
- `ServiceBriefOut` stub already existed in `memory_v1.py` (Wave 5.1b-1) with placeholder `open_jobs_count`/`active_dispatch_count` fields — updated to match the actual aggregated fields
- `build_office_brief()` and `build_finance_brief()` do NOT emit receipts (documented in the module docstring as a deliberate design choice); spec requires `build_service_brief()` to close that audit gap for the service domain

## Changes

### `orchestrator/src/aspire_orchestrator/schemas/memory_v1.py`
- Updated `ServiceBriefOut` Pydantic model: replaced placeholder `open_jobs_count`/`active_dispatch_count` fields with the actual aggregated counters:
  - `recent_picks_count` — last 5 `material_pick` decision_facts (Drew)
  - `recent_overrides_count` — last 3 `material_override` decision_facts
  - `open_pending_intents_count` — unresolved service-scope `pending_intent` memory objects
  - `recent_handoffs_count` — last 3 `handoff_note` entries with `visibility_scope=service`
  - `active_threads_count` — open `project_thread/job_thread/property_thread` with activity in last 7 days
- Updated docstring to document all fields

### `orchestrator/src/aspire_orchestrator/services/brief_materializer.py`
- Updated module docstring to document Law #2 receipt gap rationale
- Added `import uuid` and `ServiceBriefOut` import
- `_service_row_to_out()`: converts `service_brief_cache` DB row → `ServiceBriefOut`; extracts service-specific counts from `brief_json` for cache replay without re-querying
- `_fetch_service_cache()`: reads `service_brief_cache` for TTL check
- `_fetch_service_decision_facts()`: fetches `decision_fact` memory objects; client-side filters on `detail.decision_type` (PostgREST JSONB filter workaround — over-fetches then trims to limit)
- `_fetch_service_pending_intents()`: unresolved `pending_intent` in service scope
- `_fetch_service_handoffs()`: `handoff_note` entries with `visibility_scope=service`
- `_fetch_service_active_threads_count()`: counts open `project_thread/job_thread/property_thread` active in last 7 days; degrades to 0 on DB error
- `build_service_brief()`: full TTL-checked build → source aggregation → `brief_json` with embedded counts → upsert with `ON CONFLICT (tenant_id,suite_id,office_id)` → **receipt emission via `try/finally`**
- `_render_service_text()`: deterministic count-only string (Law #9 — no content)

### `orchestrator/tests/test_build_service_brief.py` (new)
24 tests across 8 categories:

| Category | Tests |
|---|---|
| Empty state | empty brief upserts; seq starts at 1 |
| With service data | picks+overrides; pending intents; handoffs; active threads |
| Cache TTL | fresh cache hit (no re-upsert); refresh=True bypasses TTL; stale triggers rebuild; seq increments |
| Receipt emission | emitted on build; counts-only in details; failure doesn't crash build; emitted on failed upsert |
| Tenant isolation | suite B sees no suite A IDs in filters; office_id mismatch → TENANT_ISOLATION_VIOLATION; upsert scoped to correct tenant |
| Error handling | upsert failure → DB_UPSERT_FAILED; threads DB error → count=0; memory fetch error → empty list |
| Concurrency | `on_conflict=tenant_id,suite_id,office_id` key present on every upsert |
| Schema | ServiceBriefOut defaults are zero; counts populated correctly |

## Verification

```
pytest orchestrator/tests/test_build_service_brief.py -v
# 24 passed in 0.14s

pytest orchestrator/tests/test_brief_materializer.py -v
# 3 passed in 0.09s (no regressions)
```

## Risks & Next Steps

- **Decision_fact JSONB filter**: `_fetch_service_decision_facts()` over-fetches and filters client-side because PostgREST's JSONB path filter encoding is fragile. If `decision_fact` volume grows large, a targeted DB index on `detail->>'decision_type'` or an RPC will be needed (future pass).
- **Active threads cap**: `_fetch_service_active_threads_count()` fetches up to 500 rows to simulate `COUNT(*)` — adequate for current volume, should be replaced with a Supabase RPC if thread counts exceed that ceiling.
- **Parallel coordination**: Do NOT merge before `feat/wave-5-1b-service-memory-routes` is ready — the `/v1/service-memory/get-memory-brief` route calls `build_service_brief()`.

## Law Compliance

- **Law #2**: `build_service_brief()` emits `memory.service_brief.built` receipt on every build attempt (success AND failure) via `try/finally`. This closes the receipt audit gap for the service domain identified in the office-memory review.
- **Law #6**: All queries scoped by `tenant_id + suite_id + office_id`. `office_id` mismatch raises `MemoryServiceError(code=TENANT_ISOLATION_VIOLATION)` at method entry. Upsert uses composite conflict key.
- **Law #9**: Only integer counts appear in logs and receipts. No memory summaries, titles, or PII are logged.
EOF
)